### PR TITLE
fix: echo_helm topic prefix mismatch (marine_autonomy/ → marine/)

### DIFF
--- a/echo_helm/src/echo_helm_node.cpp
+++ b/echo_helm/src/echo_helm_node.cpp
@@ -40,13 +40,13 @@ public:
     get_parameter("rc_mode", rc_mode_);
     RCLCPP_INFO_STREAM(get_logger(), "RC mode: " << rc_mode_);
 
-    status_publisher_ = create_publisher<marine_interfaces::msg::Heartbeat> ("marine_autonomy/status/helm", 10);
+    status_publisher_ = create_publisher<marine_interfaces::msg::Heartbeat> ("marine/status/helm", 10);
     
     cmd_vel_publisher_ = create_publisher<geometry_msgs::msg::TwistStamped>("mavros/setpoint_velocity/cmd_vel", 10);
 
     rc_override_publisher_ = create_publisher<mavros_msgs::msg::OverrideRCIn>("mavros/rc/override", 1);
 
-    cmd_vel_subscription_ = create_subscription<geometry_msgs::msg::TwistStamped>("marine_autonomy/control/cmd_vel", 10, std::bind(&EchoHelm::cmdVelCallback, this, std::placeholders::_1));
+    cmd_vel_subscription_ = create_subscription<geometry_msgs::msg::TwistStamped>("marine/control/cmd_vel", 10, std::bind(&EchoHelm::cmdVelCallback, this, std::placeholders::_1));
 
     standby_subscription_ = create_subscription<std_msgs::msg::Bool>("piloting_mode/standby/active", 5, std::bind(&EchoHelm::standbyCallback, this, std::placeholders::_1));
     


### PR DESCRIPTION
## Summary

- Rename `marine_autonomy/control/cmd_vel` → `marine/control/cmd_vel` (subscription)
- Rename `marine_autonomy/status/helm` → `marine/status/helm` (publisher)

These topics were not updated when `helm_manager` in `unh_marine_autonomy` was
renamed from the `project11`/`marine_autonomy` prefix to `marine`. This broke
the helm_manager → echo_helm control path.

## Test plan

- [ ] Build echo_helm
- [ ] Verify helm_manager cmd_vel reaches echo_helm
- [ ] Verify echo_helm heartbeat reaches helm_manager

Closes #6

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
