### PR TITLE
Update nav2 plugin names to marine_nav namespace

### DIFF
--- a/echoboat_project11/config/nav2_params.yaml
+++ b/echoboat_project11/config/nav2_params.yaml
@@ -10,7 +10,7 @@ bt_task_navigator:
     action_server_result_timeout: 900.0
     navigators: ["run_tasks",]
     run_tasks:
-      plugin: "project11_navigation::TaskNavigator"
+      plugin: "marine_nav_bt_task_navigator::TaskNavigator"
       debug: false
     # 'default_nav_through_poses_bt_xml' and 'default_nav_to_pose_bt_xml' are use defaults:
     # nav2_bt_navigator/navigate_to_pose_w_replanning_and_recovery.xml
@@ -20,7 +20,7 @@ bt_task_navigator:
     # plugin_lib_names is used to add custom BT plugins to the executor (vector of strings).
     # Built-in plugins are added automatically
     plugin_lib_names: 
-      - project11_navigation_bt_plugins
+      - marine_nav_behavior_tree_bt_plugins
 
     error_code_names:
       - compute_path_error_code
@@ -60,7 +60,7 @@ controller_server:
       xy_goal_tolerance: 4.5
       yaw_goal_tolerance: 5.0
     FollowPath:
-      plugin: "project11_navigation::controllers::CrabbingPathFollower"
+      plugin: "marine_nav_crabbing_path_follower::CrabbingPathFollower"
       default_speed: 0.75
       visualization: true
       pid:
@@ -235,7 +235,7 @@ behavior_server:
     assisted_teleop:
       plugin: "nav2_behaviors::AssistedTeleop"
     hover:
-      plugin: "project11_navigation::Hover"
+      plugin: "marine_nav_behaviors::Hover"
       minimum_radius: 2.5
       maximum_radius: 10.0
       maximum_speed: 1.0


### PR DESCRIPTION
## Summary

- Update four plugin class names in `nav2_params.yaml` from deprecated `project11_navigation` namespace to current `marine_nav_*` packages
- Aligns with `ben_project11` and `vrx_project11` configs which already use the new names

Closes #8

## Test plan

- [ ] Launch nav2 with echoboat_project11 config — controller_server, bt_task_navigator, and behavior_server should load without plugin errors

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
