### PR TITLE
feat: add manda_coverage to navigation launch

### DIFF
--- a/echoboat_project11/launch/navigation_launch.py
+++ b/echoboat_project11/launch/navigation_launch.py
@@ -49,6 +49,7 @@ def generate_launch_description():
         'velocity_smoother',
         'collision_monitor',
         #'bt_navigator',
+        'manda_coverage',
         'bt_task_navigator',
         'waypoint_follower',
         'docking_server',
@@ -180,6 +181,19 @@ def generate_launch_description():
                 # remappings=remappings + [('cmd_vel', 'cmd_vel_nav')],
                 namespace="",
                 emulate_tty=True
+            ),
+            LifecycleNode(
+                package='manda_coverage',
+                executable='manda_coverage_action_server',
+                name='manda_coverage',
+                output='screen',
+                respawn=use_respawn,
+                respawn_delay=2.0,
+                parameters=[configured_params],
+                arguments=['--ros-args', '--log-level', log_level],
+                remappings=remappings + [('soundings','sensors/deltat/soundings')],
+                namespace="",
+                emulate_tty=True,
             ),
             LifecycleNode(
                 package='nav2_bt_navigator',


### PR DESCRIPTION
## Summary

- Add `manda_coverage` (ComputeSonarCoveragePath action server) to `navigation_launch.py`
- Added as LifecycleNode with soundings topic remap
- Added to lifecycle_nodes list for proper lifecycle management
- Without this, bt_task_navigator fails activation waiting for the sonar coverage action server

Field fix from 2026-04-08 water test session. Part of rolker/unh_echoboats_project11#43.
