### PR TITLE
Field import: bump FollowPath default_speed 0.75 → 1.5 m/s (2026-04-27)

### DIFF
--- a/echoboat_project11/config/nav2_params.yaml
+++ b/echoboat_project11/config/nav2_params.yaml
@@ -61,7 +61,7 @@ controller_server:
       yaw_goal_tolerance: 5.0
     FollowPath:
       plugin: "marine_nav_crabbing_path_follower::CrabbingPathFollower"
-      default_speed: 0.75
+      default_speed: 1.5
       visualization: true
       pid:
         # upper_limit: 90.0


### PR DESCRIPTION
## Summary

Field import from gitcloud — bumps `FollowPath default_speed` from 0.75 to 1.5 m/s in `echoboat_project11/config/nav2_params.yaml`.

- 1 commit, 1-line change
- Field-verified on `gabby` 2026-04-27 (boat reported ~3 kn = 1.5 m/s)

Closes #16.

## Cross-platform footprint

This config is loaded by **both** BizzyBoat and the seafloor echoboat. Until either platform overrides, both run at 1.5 m/s default. Author flagged this and noted a future per-platform override is on the roadmap.

## Pre-review notes

- ✅ Simple, contained config
- ✅ Field-verified
- ⚠️ Affects both platforms (BizzyBoat + seafloor)
- ⚠️ Per-survey speed-specifyability is *not* enabled — separate gap in `unh_marine_navigation` BT → FollowPath integration

## Test plan

- [ ] CI on jazzy passes
- [ ] BizzyBoat survey runs at ~1.5 m/s default (already verified field-side)
- [ ] If seafloor echoboat is run before per-platform override lands, confirm 1.5 m/s is acceptable (or add override first)

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
