### PR TITLE
nav2: re-enable sea_surface_layer x4 for bizzy OAK cameras

### DIFF
--- a/.agent/work-plans/issue-18/progress.md
+++ b/.agent/work-plans/issue-18/progress.md
@@ -1,0 +1,17 @@
+---
+issue: 18
+---
+
+# Issue #18 — nav2: re-enable sea_surface_layer for bizzy's four OAK cameras
+
+## External Review
+**Status**: complete
+**When**: 2026-05-21
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #19 — 1 review (Copilot), 1 valid finding, 0 false positives
+**CI**: all pass
+
+### Actions
+- [x] Add YAML comment documenting `sea_surface_segmentation` build dependency for the shared nav2_params (Copilot finding) — committed `d7c9e1a`
+- [ ] Field-verify on bizzy: confirm `controller_server` doesn't crash with all 4 layer instances loaded

--- a/echoboat_project11/config/nav2_params.yaml
+++ b/echoboat_project11/config/nav2_params.yaml
@@ -96,6 +96,11 @@ local_costmap:
       height: 400
       resolution: 0.25
       footprint: "[[1.0, 0], [0.0, 0.3], [-0.5, 0.3], [-0.5, -0.3], [0.0, -0.3], [1.0, 0]]"
+      # Required build dependency: the `sea_surface_layer::SeaSurfaceLayer`
+      # plugin lives in the `sea_surface_segmentation` package (sensors_ws
+      # layer). Deployments using this config must have sensors_ws built —
+      # otherwise pluginlib will fail to load the layer and the local_costmap
+      # bringup will fail hard.
       plugins: ["chart_layer",
                 "sea_surface_layer_forward",
                 "sea_surface_layer_port",

--- a/echoboat_project11/config/nav2_params.yaml
+++ b/echoboat_project11/config/nav2_params.yaml
@@ -96,9 +96,12 @@ local_costmap:
       height: 400
       resolution: 0.25
       footprint: "[[1.0, 0], [0.0, 0.3], [-0.5, 0.3], [-0.5, -0.3], [0.0, -0.3], [1.0, 0]]"
-      #plugins: ["chart_layer", "obstacle_layer", "inflation_layer"]
-      #plugins: ["chart_layer", "sea_surface_layer", "inflation_layer"]
-      plugins: ["chart_layer", "inflation_layer"]
+      plugins: ["chart_layer",
+                "sea_surface_layer_forward",
+                "sea_surface_layer_port",
+                "sea_surface_layer_starboard",
+                "sea_surface_layer_aft",
+                "inflation_layer"]
       inflation_layer:
         plugin: "nav2_costmap_2d::InflationLayer"
         cost_scaling_factor: 0.05
@@ -113,11 +116,33 @@ local_costmap:
         s57_grids_namespace: <robot_namespace>/s57
         chart_datum_frame: <tf_prefix>/chart_datum
         sea_surface_frame: <tf_prefix>/map_tide
-      sea_surface_layer:
+      # Four sea_surface_layer instances, one per OAK direction. Bizzy
+      # publishes on oak_forward/port/starboard/aft; boats without a
+      # given camera produce no segmentation traffic and the matching
+      # layer stays at NO_INFORMATION (silent no-op).
+      sea_surface_layer_forward:
         plugin: "sea_surface_layer::SeaSurfaceLayer"
         enabled: True
-        segmentation_topic: <robot_namespace>/sensors/cameras/front/oak/segmentation
-        camera_info_topic: <robot_namespace>/sensors/cameras/front/oak/segmentation/camera_info
+        segmentation_topic: <robot_namespace>/sensors/cameras/oak_forward/segmentation
+        camera_info_topic: <robot_namespace>/sensors/cameras/oak_forward/segmentation/camera_info
+        maximum_range: 150.0
+      sea_surface_layer_port:
+        plugin: "sea_surface_layer::SeaSurfaceLayer"
+        enabled: True
+        segmentation_topic: <robot_namespace>/sensors/cameras/oak_port/segmentation
+        camera_info_topic: <robot_namespace>/sensors/cameras/oak_port/segmentation/camera_info
+        maximum_range: 150.0
+      sea_surface_layer_starboard:
+        plugin: "sea_surface_layer::SeaSurfaceLayer"
+        enabled: True
+        segmentation_topic: <robot_namespace>/sensors/cameras/oak_starboard/segmentation
+        camera_info_topic: <robot_namespace>/sensors/cameras/oak_starboard/segmentation/camera_info
+        maximum_range: 150.0
+      sea_surface_layer_aft:
+        plugin: "sea_surface_layer::SeaSurfaceLayer"
+        enabled: True
+        segmentation_topic: <robot_namespace>/sensors/cameras/oak_aft/segmentation
+        camera_info_topic: <robot_namespace>/sensors/cameras/oak_aft/segmentation/camera_info
         maximum_range: 150.0
       obstacle_layer:
         plugin: "nav2_costmap_2d::ObstacleLayer"


### PR DESCRIPTION
## Summary

- Replace the single-camera `sea_surface_layer` block in the shared echoboat `nav2_params.yaml` with four direction-named instances (`sea_surface_layer_forward/port/starboard/aft`), each subscribed to bizzy's actual OAK topics (`oak_<direction>/segmentation`).
- Add all four to the local_costmap `plugins` list. Removes the stale commented-out `plugins` lines.
- Boats without all four OAK directions: unmatched layer instances stay silent (no segmentation traffic → `segmentsCallback` never fires → `NO_INFORMATION`).

## Why now

[`rolker/unh_marine_perception#11`](https://github.com/rolker/unh_marine_perception/pull/11) just landed (under review) and fixes the `matchSize()` segfault that forced this layer off bizzy. Without the topic-name correction in this PR, re-enabling alone wouldn't have exercised the actual race — the old single-camera topic (`front/oak/segmentation`) was already pointing at a non-existent topic on bizzy.

## Test plan

- [ ] Field agents pull this + `unh_marine_perception#11` into bizzy's install
- [ ] Launch bizzy: `controller_server` does not crash with all 4 OAK cameras streaming
- [ ] Local costmap shows segmentation-derived costs from each OAK direction
- [ ] Closes the validation step in [`rolker/unh_marine_perception#7`](https://github.com/rolker/unh_marine_perception/issues/7)

Closes #18

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
