### PR TITLE
nav2_params.yaml: forward-only sea_surface_layer field workaround (closes #20)

### DIFF
--- a/echoboat_project11/config/nav2_params.yaml
+++ b/echoboat_project11/config/nav2_params.yaml
@@ -103,9 +103,14 @@ local_costmap:
       # bringup will fail hard.
       plugins: ["chart_layer",
                 "sea_surface_layer_forward",
-                "sea_surface_layer_port",
-                "sea_surface_layer_starboard",
-                "sea_surface_layer_aft",
+                # 2026-05-21 field workaround: port/starboard/aft
+                # commented out to dodge SeaSurfaceLayer matchSize
+                # segfault (unh_marine_perception#6). Restore the
+                # full 4-layer list once #6 is verified fixed via
+                # bench smoke.
+                # "sea_surface_layer_port",
+                # "sea_surface_layer_starboard",
+                # "sea_surface_layer_aft",
                 "inflation_layer"]
       inflation_layer:
         plugin: "nav2_costmap_2d::InflationLayer"


### PR DESCRIPTION
## Summary

Cherry-picks field commit `1eb8d2b` from `gitcloud:field/seafloor_echoboat_project11.git/jazzy`. Field workaround applied during 2026-05-21 deployment after the 4-layer config wired up by PR [#19](https://github.com/rolker/seafloor_echoboat_project11/pull/19) triggered the `SeaSurfaceLayer::matchSize` segfault that `unh_marine_perception#11` was supposed to fix.

## What changed

`echoboat_project11/config/nav2_params.yaml`: comment out `sea_surface_layer_port`, `_starboard`, `_aft` from the `local_costmap` plugins list. The plugin **definition** blocks remain unchanged (harmless if not referenced).

## Why this is a regression from #19 (and that's deliberate)

#19 wired 4 instances assuming `unh_marine_perception#11` fully fixed the segfault. Field testing today found that the fix is sufficient for **single-instance** but not for the **multi-instance** configuration #19 introduced — relaunch with the forward layer only succeeded cleanly. This PR is a clean revert of the 4-layer ambition pending an upstream fix that covers multi-instance.

## Restore condition (inline comment in the YAML documents this too)

Re-enable the full 4-layer list once the perception fix is verified to cover the multi-instance case via the [#149 Block 2 Phase 4 prep](https://github.com/rolker/unh_echoboats_project11/issues/149) bench-smoke gate: launch `controller_server` with all 4 OAK layers enabled, confirm no segfault before re-introducing the full plugins list.

## Follow-up tracked separately

`unh_marine_perception#6` was closed by PR `#11`, but the field finding shows that closure was premature for the multi-instance case. Tracked as a post-deployment item to either reopen `#6` or file a fresh `unh_marine_perception` issue against the multi-instance failure mode.

## Test plan

- [ ] Launch bizzy with this change in place: `controller_server` activates cleanly (no `matchSize` segfault).
- [ ] Local costmap shows segmentation-derived costs from the **forward** OAK camera direction (already observed working in the field).
- [ ] Port / starboard / aft layer instances remain commented out until the upstream fix is verified.

Part of #20 — restore step lands in a follow-up PR. Keeps #20 open to track the full workaround→restore lifecycle.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`

