### PR TITLE
Restore full 4-layer sea_surface_layer (closes #20)

### DIFF
--- a/echoboat_project11/config/nav2_params.yaml
+++ b/echoboat_project11/config/nav2_params.yaml
@@ -103,14 +103,9 @@ local_costmap:
       # bringup will fail hard.
       plugins: ["chart_layer",
                 "sea_surface_layer_forward",
-                # 2026-05-21 field workaround: port/starboard/aft
-                # commented out to dodge SeaSurfaceLayer matchSize
-                # segfault (unh_marine_perception#6). Restore the
-                # full 4-layer list once #6 is verified fixed via
-                # bench smoke.
-                # "sea_surface_layer_port",
-                # "sea_surface_layer_starboard",
-                # "sea_surface_layer_aft",
+                "sea_surface_layer_port",
+                "sea_surface_layer_starboard",
+                "sea_surface_layer_aft",
                 "inflation_layer"]
       inflation_layer:
         plugin: "nav2_costmap_2d::InflationLayer"


### PR DESCRIPTION
## Summary

Restores the full 4-layer `sea_surface_layer` configuration on `local_costmap` that PR #21 commented out as a field workaround. The underlying [`unh_marine_perception#6`](https://github.com/rolker/unh_marine_perception/issues/6) (the multi-instance `SeaSurfaceLayer::matchSize` segfault) is now closed — verified via bench smoke on 2026-05-21.

This is the second half of #20's workaround→restore lifecycle. PR #21 was the workaround; this PR is the restore.

## What changed

Cherry-picked field commit `bf4da10` from `gitcloud:field/seafloor_echoboat_project11.git/jazzy`. Re-enables `sea_surface_layer_port`, `_starboard`, `_aft` in the `local_costmap` plugins list. Drops the field-workaround inline comment.

## Field provenance

Per the original gitcloud commit body (`bf4da10`):

> Re-enables sea_surface_layer_port/_starboard/_aft in the local_costmap plugins list. Commented out 2026-05-21 as a field workaround for the SeaSurfaceLayer::matchSize segfault (unh_marine_perception#6); #6 verified fixed via bench smoke.

## Pre-review

Clean revert of #21's diff. No tests added (this restores prior config; nothing new to test). Verifying upstream segfault fix is the gating concern — already done per gitcloud commit message.

## Test plan

- [ ] Launch bizzy with this config: `controller_server` activates cleanly with all 4 `sea_surface_layer` instances enabled (no `matchSize` segfault).
- [ ] Local costmap shows segmentation-derived costs from all 4 OAK camera directions.
- [ ] Bench-smoke gate from [#149 Block 2 Phase 4 prep](https://github.com/rolker/unh_echoboats_project11/issues/149) re-verified, if a follow-up deployment surfaces anything.

Closes #20.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
