### PR TITLE
config(nav2): planner minimum_turning_radius 3.0 → 1.5 m

### DIFF
--- a/echoboat_project11/config/nav2_params.yaml
+++ b/echoboat_project11/config/nav2_params.yaml
@@ -242,7 +242,7 @@ planner_server:
       allow_unknown: true
       change_penalty: 0.5
       cost_penalty: 10.0
-      minimum_turning_radius: 3.0
+      minimum_turning_radius: 1.5  # was 3.0; boats turn far tighter (rolker/unh_echoboats_project11#124 §2)
       debug_visualizations: false
       max_iterations: -1
       max_on_approach_iterations: -1


### PR DESCRIPTION
## Summary

Reduce the Nav2 `SmacPlannerHybrid` **`minimum_turning_radius` 3.0 → 1.5 m**.

The 3.0 m planned radius is far wider than these vectored-thrust EchoBoats can turn — the BizzyBoat turning analysis ([rolker/unh_echoboats_project11#124](https://github.com/rolker/unh_echoboats_project11/issues/124) §2) showed ~0.9 rad/s pivots (<1 m), and BizzyBoat's helm yaw cap was raised to its 1.0 rad/s capability. A 3.0 m radius only demands ~0.5 rad/s at cruise (it matched the *old* 0.5 helm clamp), forcing unnecessarily wide line-transitions. 1.5 m ≈ 1.0 rad/s at cruise — within the raised helm cap, still well above the boats' physical pivot capability.

## Scope ⚠️

This is the **shared** Nav2 config — **BizzyBoat inherits it** (no own override), so this changes planned-path tightness for **both** the seafloor EchoBoat and BizzyBoat.

## Verification

- YAML parses; single-line change.
- **Field-untested** — planned-path geometry change. Validate on the next deployment (line-transition behavior under the new radius + BizzyBoat's raised yaw cap). Tracked in the BizzyBoat next-deployment issue.

Closes #23
Part of [rolker/unh_echoboats_project11#124](https://github.com/rolker/unh_echoboats_project11/issues/124) §2

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
