### PR TITLE
Wire reflex PointCloud2 into nav2 Collision Monitor + momentum polygons (BizzyBoat reflex safety, Phase B)

### DIFF
--- a/.agent/work-plans/issue-25/plan.md
+++ b/.agent/work-plans/issue-25/plan.md
@@ -31,32 +31,34 @@ topic `collision_monitor/pointcloud` (→ `/bizzy/collision_monitor/pointcloud`)
    reflex_cloud:
      type: "pointcloud"
      topic: "collision_monitor/pointcloud"
-     min_height: -0.5        # cloud is flat at plane_z≈0 in base_link_level;
-     max_height:  0.5        # bracket it generously (hull-floor vs waterline)
+     min_height: -2.0        # spans the projected plane (z≈0 in base_link_level)
+     max_height:  2.0        # + pitch-induced z-shift of far points in base_link
      enabled: True
    ```
-   (Keep `FootprintApproach` as-is, or see step 2.) The shared-params change is
-   a no-op for izzy until it sets `publish_pointcloud: true` and remaps its
-   reflex cloud to the same canonical topic — document inline.
+   The shared-params change is a no-op for izzy until it sets
+   `publish_pointcloud: true` and remaps its reflex cloud to the same canonical
+   topic — documented inline. **Done.**
 
-2. **Tune polygons for boat momentum** (`nav2_params.yaml:343-352`). Passive
-   coast-down is ~10–15 m from ~1.5 m/s cruise (#124 §2 / PR #172). Favor
-   **slowdown/limit over hard stop**, forward-arc only. Starting geometry
-   (forward +x, ±beam in y; tune in sim/field):
-   - a **`slowdown`** (or `limit`) polygon covering the forward sector out to
-     **well beyond 15 m** (e.g. x∈[0, 20] m, |y|≤ ~3 m) — scales velocity down
-     on first detection so the boat bleeds speed within coast-down distance;
-   - a close-in **`stop`** polygon (e.g. x∈[0, 3] m) as last resort.
-   `min_points` set to the cloud's realistic presence threshold (the reflex
-   cloud is sparse — ~tens of points; Phase A measured ≤~53). Whether to add a
-   reverse/back-off action for obstacles already inside coast-down distance is
-   an **open question** (see below).
+2. **Tune polygons for boat momentum** — **DONE** (geometry is a starting
+   point, refine in sim). Passive coast-down is ~10–15 m from ~1.5 m/s cruise
+   (#124 §2 / PR #172), so favor slowdown over hard stop, forward-arc only.
+   `FootprintApproach` (the old default, blind on the nonexistent `scan`) is
+   **replaced** by two explicit forward-sector polygons:
+   - `CollisionSlowdown` — x∈[0, 20] m, |y|≤3 m, `slowdown_ratio: 0.3`,
+     `min_points: 4`. Bleeds speed well before stopping distance.
+   - `CollisionStop` — x∈[0, 5] m, |y|≤2 m, `min_points: 5`. Last resort.
 
-3. **Fix `base_frame_id`** (`nav2_params.yaml:331`): currently hardcoded
-   `"base_footprint"` with no `<tf_prefix>`. The monitor transforms
-   observations into `base_frame_id`, so it must be a real frame in bizzy's TF
-   tree. Verify and, if needed, switch to `<tf_prefix>/base_link` (the
-   reflex cloud is in `bizzy/base_link_level`; confirm the chain resolves).
+   `min_points` reflects the sparse reflex cloud (~tens of pts; Phase A measured
+   ≤~53). **Reverse-action question resolved**: nav2_collision_monitor has no
+   reverse action (stop/slowdown/limit/approach only), so the early-standoff
+   slowdown zone *is* the momentum mechanism.
+
+3. **Fix `base_frame_id`** — **DONE**. Was hardcoded `"base_footprint"` (no
+   prefix, frame absent from the boat TF trees); changed to
+   `<tf_prefix>/base_link`, matching every other frame in this file
+   (costmaps + docking). The reflex cloud (`bizzy/base_link_level`) is
+   TF-transformed into it; small pitch/roll error is folded into the height
+   bracket + polygon-sizing budget.
 
 4. **Sim-verify before field** (non-negotiable per #170): bring up nav2 +
    collision_monitor in sim, inject/replay a forward reflex cloud, and confirm
@@ -92,19 +94,30 @@ topic `collision_monitor/pointcloud` (→ `/bizzy/collision_monitor/pointcloud`)
 | If we change... | Also update... | Included? |
 |---|---|---|
 | Shared `collision_monitor` observation source | izzy opts in later (publish_pointcloud + remap) — no-op until then | Documented inline |
-| Polygon block (shared) | If bizzy/izzy tuning must diverge, add a per-boat override | Flagged — open question |
-| `base_frame_id` | Confirm frame exists in bizzy TF tree | Step 3 |
+| Polygon block (shared) | If bizzy/izzy tuning must diverge, add a per-boat override | Kept shared (revisit if needed) |
+| `base_frame_id` | Use a frame present in both boats' TF trees | Done — `<tf_prefix>/base_link` |
 
 ## Open Questions
 
-- [ ] **Reverse vs stop inside coast-down distance** — for an obstacle already
-  within ~15 m, zero-throttle still coasts into it. Add a reverse/back-off
-  action, or accept slowdown+stop and rely on the standoff zone catching
-  obstacles earlier? (Active crash-stop braking is uncharacterized — #88.)
-- [ ] **Shared vs per-boat polygons** — keep one shared polygon block, or does
-  bizzy's momentum/size warrant a bizzy-specific override now?
-- [ ] **Polygon geometry numbers** — starting values above are estimates;
-  finalize against sim + the Phase C offline trigger catalog (#169).
+- [x] **Reverse vs stop** — resolved: CM has no reverse action; rely on the
+  early-standoff slowdown zone. (Active crash-stop braking still uncharacterized
+  — #88.)
+- [x] **Shared vs per-boat polygons** — resolved for now: kept shared (izzy is a
+  no-op until it opts in). Revisit only if bizzy/izzy tuning must diverge.
+- [ ] **Polygon geometry + slowdown_ratio + min_points + height bracket** — the
+  landed values (20 m slowdown / 5 m stop / ratio 0.3 / ±2 m height) are
+  estimates. Finalize against **sim verification** and the Phase C offline
+  trigger catalog (#169). This is the gate before the PR leaves draft.
+
+## Implementation Notes
+
+- Replaced the default `FootprintApproach` (approach-type, bound to the
+  nonexistent `scan` source) with explicit `CollisionSlowdown` + `CollisionStop`
+  polygons. Rationale: the issue calls for slowdown-first with a realistic
+  standoff; explicit forward-sector slowdown/stop zones are easier to reason
+  about and tune for boat momentum than approach-type time-to-collision on a
+  sparse, forward-only cloud. No izzy regression — its monitor was already blind
+  (same shared `scan` source it never publishes).
 
 ## Estimated Scope
 

--- a/.agent/work-plans/issue-25/plan.md
+++ b/.agent/work-plans/issue-25/plan.md
@@ -105,9 +105,20 @@ topic `collision_monitor/pointcloud` (→ `/bizzy/collision_monitor/pointcloud`)
 - [x] **Shared vs per-boat polygons** — resolved for now: kept shared (izzy is a
   no-op until it opts in). Revisit only if bizzy/izzy tuning must diverge.
 - [ ] **Polygon geometry + slowdown_ratio + min_points + height bracket** — the
-  landed values (20 m slowdown / 5 m stop / ratio 0.3 / ±2 m height) are
-  estimates. Finalize against **sim verification** and the Phase C offline
-  trigger catalog (#169). This is the gate before the PR leaves draft.
+  landed values (20 m slowdown / 5 m stop / ratio 0.3 / min_points 4–5 / ±2 m
+  height) are estimates. Finalize against **sim verification** and the Phase C
+  offline trigger catalog (#169). This is the gate before the PR leaves draft.
+  Two review signals to resolve empirically here:
+  - **min_points direction is contested** — the cross-model reviewers split:
+    one flagged 4–5 as too *high* (misses small/distant obstacles → false
+    negatives, the collision risk), the other as too *low* (noise → nuisance
+    survey stops). Sim/Phase-C data decides; bias toward sensitivity given the
+    motivating failure is missed obstacles.
+  - **Suddenly-appearing close obstacle** — slowdown-first only protects when
+    the obstacle is seen far out. An obstacle first detected inside ~5 m (sharp
+    turn, sudden surfacing) still coasts ~10–15 m past a `stop`. Inherent to
+    passive braking with no reverse (#88); consider a graduated inner slowdown
+    (e.g. 5–10 m at a lower ratio) during tuning rather than enlarging `stop`.
 
 ## Implementation Notes
 

--- a/.agent/work-plans/issue-25/plan.md
+++ b/.agent/work-plans/issue-25/plan.md
@@ -1,0 +1,112 @@
+# Plan: Wire reflex PointCloud2 into nav2 Collision Monitor + tune polygons (Phase B)
+
+## Issue
+
+https://github.com/rolker/seafloor_echoboat_project11/issues/25
+
+## Context
+
+Phase B of the BizzyBoat reflex safety layer (umbrella
+`rolker/unh_echoboats_project11#170`; adapter `rolker/unh_marine_perception#17`;
+Phase A `rolker/unh_echoboats_project11#178`).
+
+`echoboat_project11/config/nav2_params.yaml` already defines `collision_monitor:`
+correctly gated on the autonomous cmd_vel path (`cmd_vel_smoothed` →
+`piloting_mode/autonomous/cmd_vel`, ahead of the mavros setpoint). Its only
+`observation_sources` is `scan` (a LaserScan BizzyBoat never publishes) and its
+only polygon is `FootprintApproach` (costmap-footprint approach type). So the
+monitor is **blind** today. This params file is **shared** by bizzy and izzy
+(bizzy's `nav_launch.py` passes no override).
+
+Phase A publishes/records/bridges the reflex cloud on the canonical relative
+topic `collision_monitor/pointcloud` (→ `/bizzy/collision_monitor/pointcloud`).
+
+## Approach
+
+1. **Swap the observation source** (`nav2_params.yaml:353-358`): replace
+   `observation_sources: ["scan"]` + the `scan` block with a `pointcloud`
+   source on the canonical relative topic `collision_monitor/pointcloud`:
+   ```yaml
+   observation_sources: ["reflex_cloud"]
+   reflex_cloud:
+     type: "pointcloud"
+     topic: "collision_monitor/pointcloud"
+     min_height: -0.5        # cloud is flat at plane_z≈0 in base_link_level;
+     max_height:  0.5        # bracket it generously (hull-floor vs waterline)
+     enabled: True
+   ```
+   (Keep `FootprintApproach` as-is, or see step 2.) The shared-params change is
+   a no-op for izzy until it sets `publish_pointcloud: true` and remaps its
+   reflex cloud to the same canonical topic — document inline.
+
+2. **Tune polygons for boat momentum** (`nav2_params.yaml:343-352`). Passive
+   coast-down is ~10–15 m from ~1.5 m/s cruise (#124 §2 / PR #172). Favor
+   **slowdown/limit over hard stop**, forward-arc only. Starting geometry
+   (forward +x, ±beam in y; tune in sim/field):
+   - a **`slowdown`** (or `limit`) polygon covering the forward sector out to
+     **well beyond 15 m** (e.g. x∈[0, 20] m, |y|≤ ~3 m) — scales velocity down
+     on first detection so the boat bleeds speed within coast-down distance;
+   - a close-in **`stop`** polygon (e.g. x∈[0, 3] m) as last resort.
+   `min_points` set to the cloud's realistic presence threshold (the reflex
+   cloud is sparse — ~tens of points; Phase A measured ≤~53). Whether to add a
+   reverse/back-off action for obstacles already inside coast-down distance is
+   an **open question** (see below).
+
+3. **Fix `base_frame_id`** (`nav2_params.yaml:331`): currently hardcoded
+   `"base_footprint"` with no `<tf_prefix>`. The monitor transforms
+   observations into `base_frame_id`, so it must be a real frame in bizzy's TF
+   tree. Verify and, if needed, switch to `<tf_prefix>/base_link` (the
+   reflex cloud is in `bizzy/base_link_level`; confirm the chain resolves).
+
+4. **Sim-verify before field** (non-negotiable per #170): bring up nav2 +
+   collision_monitor in sim, inject/replay a forward reflex cloud, and confirm
+   the monitor slows/stops `piloting_mode/autonomous/cmd_vel` when points fall
+   in the forward danger sector — and passes through when clear. Confirm the
+   manual RC-direct-to-FCU path is unaffected.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `echoboat_project11/config/nav2_params.yaml` | Swap `scan`→`pointcloud` observation source on `collision_monitor/pointcloud`; add slowdown + stop polygons tuned for momentum; verify/fix `base_frame_id` |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Robustness (boat on open water) | Slowdown-first + standoff beyond coast-down distance; stop as last resort; manual path untouched. |
+| Test what breaks | Sim verification of actual cmd_vel gating is the acceptance gate, not just config parse. |
+| A change includes its consequences | Shared-params effect on izzy documented; `base_frame_id` correctness folded in, not deferred. |
+| Capture decisions | Slowdown-over-stop, canonical-topic source, reverse-action open question recorded. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0002 — Worktree isolation | Yes | `layers/worktrees/issue-seafloor_echoboat_project11-25`. |
+| 0008 — ROS 2 conventions | Yes | nav2 plugin params; canonical relative topic; sensor_msgs/PointCloud2. |
+| 0013 — progress.md vocabulary | Yes | `## Plan Authored` entry appended. |
+
+## Consequences
+
+| If we change... | Also update... | Included? |
+|---|---|---|
+| Shared `collision_monitor` observation source | izzy opts in later (publish_pointcloud + remap) — no-op until then | Documented inline |
+| Polygon block (shared) | If bizzy/izzy tuning must diverge, add a per-boat override | Flagged — open question |
+| `base_frame_id` | Confirm frame exists in bizzy TF tree | Step 3 |
+
+## Open Questions
+
+- [ ] **Reverse vs stop inside coast-down distance** — for an obstacle already
+  within ~15 m, zero-throttle still coasts into it. Add a reverse/back-off
+  action, or accept slowdown+stop and rely on the standoff zone catching
+  obstacles earlier? (Active crash-stop braking is uncharacterized — #88.)
+- [ ] **Shared vs per-boat polygons** — keep one shared polygon block, or does
+  bizzy's momentum/size warrant a bizzy-specific override now?
+- [ ] **Polygon geometry numbers** — starting values above are estimates;
+  finalize against sim + the Phase C offline trigger catalog (#169).
+
+## Estimated Scope
+
+Single PR against seafloor `jazzy`, but the polygon numbers are sim/field-tuned
+— expect iteration. Pairs with Phase A (#178) and the Phase C trigger catalog.

--- a/.agent/work-plans/issue-25/progress.md
+++ b/.agent/work-plans/issue-25/progress.md
@@ -18,3 +18,20 @@ issue: 25
 - [ ] Shared polygon block vs bizzy-specific override.
 - [ ] Final polygon geometry numbers (sim + Phase C trigger catalog).
 - [ ] base_frame_id ("base_footprint") correctness in bizzy's namespaced TF tree.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-05-26 10:39 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+**Verdict**: approved (draft held for sim verification)
+
+**Branch**: feature/issue-25 at `584775b`
+**Mode**: pre-push
+**Depth**: Standard (reason: safety-critical collision-monitor behavior change)
+**Must-fix**: 0 | **Suggestions**: 2
+
+### Findings
+- [x] (debunked) Copilot "YAML syntax error" on `base_frame_id: <tf_prefix>/base_link` — false positive; raw file parses, unquoted `<tf_prefix>` is the file-wide convention (10+ pre-existing lines).
+- [ ] (tune) `min_points` direction contested across reviewers (too-high vs too-low) — resolve in sim/Phase-C; bias toward sensitivity (missed obstacles are the collision risk) — `nav2_params.yaml` CollisionSlowdown/CollisionStop
+- [ ] (limitation) suddenly-appearing obstacle inside ~5 m still coasts past `stop`; consider graduated inner slowdown in tuning, not a larger stop zone (#88) — `nav2_params.yaml`
+- [ ] (gate) sim-verify cmd_vel slow/stop on forward danger sector + RC path unaffected before PR leaves draft

--- a/.agent/work-plans/issue-25/progress.md
+++ b/.agent/work-plans/issue-25/progress.md
@@ -1,0 +1,20 @@
+---
+issue: 25
+---
+
+# Issue #25 — Wire reflex PointCloud2 into nav2 Collision Monitor + tune polygons (Phase B)
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-05-26 09:54 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**Plan**: `.agent/work-plans/issue-25/plan.md` at `3395573`
+**PR**: https://github.com/rolker/seafloor_echoboat_project11/pull/26 (`[PLAN]` prefix)
+**Phases**: single PR (part of #170; pairs with Phase A #178 and Phase C #169)
+
+### Open questions
+- [ ] Reverse/back-off action vs slowdown+stop for obstacles already inside ~15 m coast-down distance.
+- [ ] Shared polygon block vs bizzy-specific override.
+- [ ] Final polygon geometry numbers (sim + Phase C trigger catalog).
+- [ ] base_frame_id ("base_footprint") correctness in bizzy's namespaced TF tree.

--- a/echoboat_project11/config/nav2_params.yaml
+++ b/echoboat_project11/config/nav2_params.yaml
@@ -328,7 +328,7 @@ velocity_smoother:
 
 collision_monitor:
   ros__parameters:
-    base_frame_id: "base_footprint"
+    base_frame_id: <tf_prefix>/base_link
     odom_frame_id: <tf_prefix>/odom
     cmd_vel_in_topic: "cmd_vel_smoothed"
     cmd_vel_out_topic: "piloting_mode/autonomous/cmd_vel"
@@ -340,21 +340,39 @@ collision_monitor:
     stop_pub_timeout: 2.0
     # Polygons represent zone around the robot for "stop", "slowdown" and "limit" action types,
     # and robot footprint for "approach" action type.
-    polygons: ["FootprintApproach"]
-    FootprintApproach:
+    # Forward-arc zones (single forward camera), base_link x-fwd / y-port.
+    # Tuned for boat momentum: passive coast-down ~10-15 m from ~1.5 m/s
+    # cruise (#124 §2 / PR #172), so slowdown stands off well beyond stopping
+    # distance to bleed speed early; stop is last-resort. CM has no reverse
+    # action. Starting geometry — refine in sim + Phase C trigger catalog (#169).
+    polygons: ["CollisionSlowdown", "CollisionStop"]
+    CollisionSlowdown:
       type: "polygon"
-      action_type: "approach"
-      footprint_topic: "local_costmap/published_footprint"
-      time_before_collision: 1.2
-      simulation_time_step: 0.1
-      min_points: 6
-      visualize: False
+      points: "[[20.0, 3.0], [20.0, -3.0], [0.0, -3.0], [0.0, 3.0]]"
+      action_type: "slowdown"
+      slowdown_ratio: 0.3
+      min_points: 4
+      visualize: True
+      polygon_pub_topic: "collision_monitor/slowdown_polygon"
       enabled: True
-    observation_sources: ["scan"]
-    scan:
-      type: "scan"
-      topic: "scan"
-      min_height: 0.15
+    CollisionStop:
+      type: "polygon"
+      points: "[[5.0, 2.0], [5.0, -2.0], [0.0, -2.0], [0.0, 2.0]]"
+      action_type: "stop"
+      min_points: 5
+      visualize: True
+      polygon_pub_topic: "collision_monitor/stop_polygon"
+      enabled: True
+    observation_sources: ["reflex_cloud"]
+    # Reflex PointCloud2 from the forward-OAK segmentation adapter
+    # (perception#17), on the canonical per-boat topic (bizzy:
+    # unh_echoboats_project11#178). Sparse (~tens of pts). Height bracket
+    # spans the projected plane (z~=0 in base_link_level) plus the pitch-
+    # induced z-shift of far points once transformed into base_link.
+    reflex_cloud:
+      type: "pointcloud"
+      topic: "collision_monitor/pointcloud"
+      min_height: -2.0
       max_height: 2.0
       enabled: True
 


### PR DESCRIPTION
Closes #25

> **Status (config landed, draft):** the collision_monitor is now wired to the
> reflex PointCloud2 (`collision_monitor/pointcloud`) with momentum-tuned
> slowdown (0–20 m, ratio 0.3) + stop (0–5 m) polygons; `base_frame_id` fixed to
> `<tf_prefix>/base_link`. Pre-push review: **0 must-fix** (a Copilot "YAML
> syntax" flag was a verified false positive). **Held as draft pending sim
> verification** — the polygon geometry / `min_points` / height bracket are
> sim+Phase-C-tunable starting values (reviewers split on `min_points`
> direction). Part of rolker/unh_echoboats_project11#170; pairs with Phase A
> rolker/unh_echoboats_project11#178.

---

# Plan: Wire reflex PointCloud2 into nav2 Collision Monitor + tune polygons (Phase B)

## Issue

https://github.com/rolker/seafloor_echoboat_project11/issues/25

## Context

Phase B of the BizzyBoat reflex safety layer (umbrella
`rolker/unh_echoboats_project11#170`; adapter `rolker/unh_marine_perception#17`;
Phase A `rolker/unh_echoboats_project11#178`).

`echoboat_project11/config/nav2_params.yaml` already defines `collision_monitor:`
correctly gated on the autonomous cmd_vel path (`cmd_vel_smoothed` →
`piloting_mode/autonomous/cmd_vel`, ahead of the mavros setpoint). Its only
`observation_sources` is `scan` (a LaserScan BizzyBoat never publishes) and its
only polygon is `FootprintApproach` (costmap-footprint approach type). So the
monitor is **blind** today. This params file is **shared** by bizzy and izzy
(bizzy's `nav_launch.py` passes no override).

Phase A publishes/records/bridges the reflex cloud on the canonical relative
topic `collision_monitor/pointcloud` (→ `/bizzy/collision_monitor/pointcloud`).

## Approach

1. **Swap the observation source** (`nav2_params.yaml:353-358`): replace
   `observation_sources: ["scan"]` + the `scan` block with a `pointcloud`
   source on the canonical relative topic `collision_monitor/pointcloud`:
   ```yaml
   observation_sources: ["reflex_cloud"]
   reflex_cloud:
     type: "pointcloud"
     topic: "collision_monitor/pointcloud"
     min_height: -2.0        # spans the projected plane (z≈0 in base_link_level)
     max_height:  2.0        # + pitch-induced z-shift of far points in base_link
     enabled: True
   ```
   The shared-params change is a no-op for izzy until it sets
   `publish_pointcloud: true` and remaps its reflex cloud to the same canonical
   topic — documented inline. **Done.**

2. **Tune polygons for boat momentum** — **DONE** (geometry is a starting
   point, refine in sim). Passive coast-down is ~10–15 m from ~1.5 m/s cruise
   (#124 §2 / PR #172), so favor slowdown over hard stop, forward-arc only.
   `FootprintApproach` (the old default, blind on the nonexistent `scan`) is
   **replaced** by two explicit forward-sector polygons:
   - `CollisionSlowdown` — x∈[0, 20] m, |y|≤3 m, `slowdown_ratio: 0.3`,
     `min_points: 4`. Bleeds speed well before stopping distance.
   - `CollisionStop` — x∈[0, 5] m, |y|≤2 m, `min_points: 5`. Last resort.

   `min_points` reflects the sparse reflex cloud (~tens of pts; Phase A measured
   ≤~53). **Reverse-action question resolved**: nav2_collision_monitor has no
   reverse action (stop/slowdown/limit/approach only), so the early-standoff
   slowdown zone *is* the momentum mechanism.

3. **Fix `base_frame_id`** — **DONE**. Was hardcoded `"base_footprint"` (no
   prefix, frame absent from the boat TF trees); changed to
   `<tf_prefix>/base_link`, matching every other frame in this file
   (costmaps + docking). The reflex cloud (`bizzy/base_link_level`) is
   TF-transformed into it; small pitch/roll error is folded into the height
   bracket + polygon-sizing budget.

4. **Sim-verify before field** (non-negotiable per #170): bring up nav2 +
   collision_monitor in sim, inject/replay a forward reflex cloud, and confirm
   the monitor slows/stops `piloting_mode/autonomous/cmd_vel` when points fall
   in the forward danger sector — and passes through when clear. Confirm the
   manual RC-direct-to-FCU path is unaffected.

## Files to Change

| File | Change |
|------|--------|
| `echoboat_project11/config/nav2_params.yaml` | Swap `scan`→`pointcloud` observation source on `collision_monitor/pointcloud`; add slowdown + stop polygons tuned for momentum; verify/fix `base_frame_id` |

## Principles Self-Check

| Principle | Consideration |
|---|---|
| Robustness (boat on open water) | Slowdown-first + standoff beyond coast-down distance; stop as last resort; manual path untouched. |
| Test what breaks | Sim verification of actual cmd_vel gating is the acceptance gate, not just config parse. |
| A change includes its consequences | Shared-params effect on izzy documented; `base_frame_id` correctness folded in, not deferred. |
| Capture decisions | Slowdown-over-stop, canonical-topic source, reverse-action open question recorded. |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| 0002 — Worktree isolation | Yes | `layers/worktrees/issue-seafloor_echoboat_project11-25`. |
| 0008 — ROS 2 conventions | Yes | nav2 plugin params; canonical relative topic; sensor_msgs/PointCloud2. |
| 0013 — progress.md vocabulary | Yes | `## Plan Authored` entry appended. |

## Consequences

| If we change... | Also update... | Included? |
|---|---|---|
| Shared `collision_monitor` observation source | izzy opts in later (publish_pointcloud + remap) — no-op until then | Documented inline |
| Polygon block (shared) | If bizzy/izzy tuning must diverge, add a per-boat override | Kept shared (revisit if needed) |
| `base_frame_id` | Use a frame present in both boats' TF trees | Done — `<tf_prefix>/base_link` |

## Open Questions

- [x] **Reverse vs stop** — resolved: CM has no reverse action; rely on the
  early-standoff slowdown zone. (Active crash-stop braking still uncharacterized
  — #88.)
- [x] **Shared vs per-boat polygons** — resolved for now: kept shared (izzy is a
  no-op until it opts in). Revisit only if bizzy/izzy tuning must diverge.
- [ ] **Polygon geometry + slowdown_ratio + min_points + height bracket** — the
  landed values (20 m slowdown / 5 m stop / ratio 0.3 / min_points 4–5 / ±2 m
  height) are estimates. Finalize against **sim verification** and the Phase C
  offline trigger catalog (#169). This is the gate before the PR leaves draft.
  Two review signals to resolve empirically here:
  - **min_points direction is contested** — the cross-model reviewers split:
    one flagged 4–5 as too *high* (misses small/distant obstacles → false
    negatives, the collision risk), the other as too *low* (noise → nuisance
    survey stops). Sim/Phase-C data decides; bias toward sensitivity given the
    motivating failure is missed obstacles.
  - **Suddenly-appearing close obstacle** — slowdown-first only protects when
    the obstacle is seen far out. An obstacle first detected inside ~5 m (sharp
    turn, sudden surfacing) still coasts ~10–15 m past a `stop`. Inherent to
    passive braking with no reverse (#88); consider a graduated inner slowdown
    (e.g. 5–10 m at a lower ratio) during tuning rather than enlarging `stop`.

## Implementation Notes

- Replaced the default `FootprintApproach` (approach-type, bound to the
  nonexistent `scan` source) with explicit `CollisionSlowdown` + `CollisionStop`
  polygons. Rationale: the issue calls for slowdown-first with a realistic
  standoff; explicit forward-sector slowdown/stop zones are easier to reason
  about and tune for boat momentum than approach-type time-to-collision on a
  sparse, forward-only cloud. No izzy regression — its monitor was already blind
  (same shared `scan` source it never publishes).

## Estimated Scope

Single PR against seafloor `jazzy`, but the polygon numbers are sim/field-tuned
— expect iteration. Pairs with Phase A (#178) and the Phase C trigger catalog.
