### PR TITLE
Route autonomous cmd_vel through Collision Monitor (field import, #27)

### DIFF
--- a/.agent/work-plans/issue-27/progress.md
+++ b/.agent/work-plans/issue-27/progress.md
@@ -1,0 +1,30 @@
+---
+issue: 27
+---
+
+# Issue #27 — Collision Monitor stranded on dead input — route autonomous cmd_vel through the monitor
+
+## Local Review
+**Status**: complete
+**When**: 2026-05-26 17:12 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+**Verdict**: changes-requested (addressed in `b213dd0`)
+
+**PR**: #28 at `b213dd0`
+**Mode**: post-PR
+**Depth**: Standard (reason: autonomous e-stop safety path)
+**Must-fix**: 1 | **Suggestions**: 3
+
+Active (non-composition, `use_composition=False`) path verified correct and
+field-verified: controller/behaviors → `cmd_vel_nav` → collision_monitor →
+`piloting_mode/autonomous/cmd_vel` → helm; no lifecycle-manager hang, no
+double-publisher. Static analysis clean for the diff (remaining flake8 hits are
+pre-existing untouched lines 51/64/196/293). Cross-model adversarial (Claude +
+Copilot) both flagged the composition path.
+
+### Findings
+- [x] (must-fix) Composition path left half-migrated + inaccurate NOTE comment; mirrored the smoother removal into `load_composable_nodes` so a future `use_composition=True` can't reintroduce the gating bypass — `launch/navigation_launch.py:272` (fixed in `b213dd0`)
+- [x] (suggestion) Safe routing depended on unenforced `use_composition=False` default — resolved by making both paths consistent — `launch/navigation_launch.py:277`
+- [x] (suggestion) No-op `('cmd_vel', …)` remap on composition `collision_monitor` removed — `launch/navigation_launch.py:351`
+- [ ] (suggestion) `velocity_smoother:` param block retained in `nav2_params.yaml` while the node is gone from both paths — harmless (unused params, intentional per "re-enable later" note); leave for a future cleanup
+- [ ] (note) seafloor repo has no `.pre-commit-config.yaml` and no `.agents/README.md` — pre-existing governance gaps, out of scope for #27

--- a/.agent/work-plans/issue-27/progress.md
+++ b/.agent/work-plans/issue-27/progress.md
@@ -28,3 +28,21 @@ Copilot) both flagged the composition path.
 - [x] (suggestion) No-op `('cmd_vel', …)` remap on composition `collision_monitor` removed — `launch/navigation_launch.py:351`
 - [ ] (suggestion) `velocity_smoother:` param block retained in `nav2_params.yaml` while the node is gone from both paths — harmless (unused params, intentional per "re-enable later" note); leave for a future cleanup
 - [ ] (note) seafloor repo has no `.pre-commit-config.yaml` and no `.agents/README.md` — pre-existing governance gaps, out of scope for #27
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-05-26 17:21 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #28 at `60a7825`
+**Sources**: 2 (GitHub Copilot reviewer @ `ffbc57a`, Local Review @ `b213dd0`; CI rollup empty)
+**Cross-source confirmations**: 1
+**CI**: no checks configured on seafloor repo
+
+### Findings
+- [x] (cross-confirmed: GitHub Copilot @ `ffbc57a` + Local Review @ `b213dd0` + review-code Claude/Copilot adversarial) Composition-path NOTE inaccurate + path half-migrated; resolved in `b213dd0` (velocity_smoother removed from composition path, NOTE rewritten). GitHub Copilot review is stale (against pre-fix `ffbc57a`) — `launch/navigation_launch.py`
+- [ ] (suggestion, Local Review) `velocity_smoother:` param block retained in `nav2_params.yaml` — harmless unused params, intentionally deferred
+- [ ] (note) Optional: reply-to/dismiss the stale Copilot review on the PR to keep the conversation clean (no code action)
+
+### False positives
+- (none) — Copilot's comment was correct, just already addressed by `b213dd0` before it posted

--- a/echoboat_project11/config/nav2_params.yaml
+++ b/echoboat_project11/config/nav2_params.yaml
@@ -330,7 +330,7 @@ collision_monitor:
   ros__parameters:
     base_frame_id: <tf_prefix>/base_link
     odom_frame_id: <tf_prefix>/odom
-    cmd_vel_in_topic: "cmd_vel_smoothed"
+    cmd_vel_in_topic: "cmd_vel_nav"          # controller/behaviors publish here; monitor gates → out (#170)
     cmd_vel_out_topic: "piloting_mode/autonomous/cmd_vel"
     enable_stamped_cmd_vel: true
     state_topic: "collision_monitor_state"

--- a/echoboat_project11/launch/navigation_launch.py
+++ b/echoboat_project11/launch/navigation_launch.py
@@ -46,7 +46,7 @@ def generate_launch_description():
         'smoother_server',
         'planner_server',
         'behavior_server',
-        'velocity_smoother',
+        # velocity_smoother removed from the active path (#170) — see node block below
         'collision_monitor',
         #'bt_navigator',
         'manda_coverage',
@@ -137,8 +137,9 @@ def generate_launch_description():
                 respawn_delay=2.0,
                 parameters=[configured_params],
                 arguments=['--ros-args', '--log-level', log_level],
-                remappings=remappings + [('cmd_vel', 'piloting_mode/autonomous/cmd_vel')],
-                #remappings=remappings + [('cmd_vel', 'cmd_vel_nav')],
+                # Route controller output into the Collision Monitor via cmd_vel_nav,
+                # not straight to the helm topic, so the monitor can gate it (#170).
+                remappings=remappings + [('cmd_vel', 'cmd_vel_nav')],
                 namespace="",
                 emulate_tty=True
             ),
@@ -177,8 +178,9 @@ def generate_launch_description():
                 respawn_delay=2.0,
                 parameters=[configured_params],
                 arguments=['--ros-args', '--log-level', log_level],
-                remappings=remappings + [('cmd_vel', 'piloting_mode/autonomous/cmd_vel')],
-                # remappings=remappings + [('cmd_vel', 'cmd_vel_nav')],
+                # Route recovery-behavior cmd_vel through the Collision Monitor too,
+                # via cmd_vel_nav (#170).
+                remappings=remappings + [('cmd_vel', 'cmd_vel_nav')],
                 namespace="",
                 emulate_tty=True
             ),
@@ -221,20 +223,14 @@ def generate_launch_description():
                 namespace="",
                 emulate_tty=True
             ),
-            LifecycleNode(
-                package='nav2_velocity_smoother',
-                executable='velocity_smoother',
-                name='velocity_smoother',
-                output='screen',
-                respawn=use_respawn,
-                respawn_delay=2.0,
-                parameters=[configured_params],
-                arguments=['--ros-args', '--log-level', log_level],
-                remappings=remappings
-                + [('cmd_vel', 'cmd_vel_nav'), ('cmd_vel_smoothed', 'piloting_mode/autonomous/cmd_vel')],
-                namespace="",
-                emulate_tty=True
-            ),
+            # velocity_smoother intentionally removed from the active path (#170).
+            # The cmd_vel filter chain is deliberately disconnected on these boats,
+            # so the controller feeds the Collision Monitor directly via cmd_vel_nav.
+            # Leaving the smoother here would put a second publisher on
+            # piloting_mode/autonomous/cmd_vel, competing with the monitor. To
+            # re-enable smoothing later, restore this node with its output remapped
+            # to cmd_vel_smoothed and set collision_monitor cmd_vel_in_topic back to
+            # cmd_vel_smoothed (and re-add 'velocity_smoother' to lifecycle_nodes).
             LifecycleNode(
                 package='nav2_collision_monitor',
                 executable='collision_monitor',
@@ -273,6 +269,11 @@ def generate_launch_description():
         ],
     )
 
+    # NOTE (#170): this composition path is NOT updated for the Collision-Monitor
+    # rewire and is currently UNUSED on the project11 boats (use_composition=False).
+    # It still routes velocity_smoother -> piloting_mode/autonomous/cmd_vel, leaving
+    # the monitor's input orphaned (same bug fixed in the non-composition path
+    # above). Mirror the non-composition changes here before enabling composition.
     load_composable_nodes = GroupAction(
         condition=IfCondition(use_composition),
         actions=[

--- a/echoboat_project11/launch/navigation_launch.py
+++ b/echoboat_project11/launch/navigation_launch.py
@@ -269,11 +269,14 @@ def generate_launch_description():
         ],
     )
 
-    # NOTE (#170): this composition path is NOT updated for the Collision-Monitor
-    # rewire and is currently UNUSED on the project11 boats (use_composition=False).
-    # It still routes velocity_smoother -> piloting_mode/autonomous/cmd_vel, leaving
-    # the monitor's input orphaned (same bug fixed in the non-composition path
-    # above). Mirror the non-composition changes here before enabling composition.
+    # NOTE (#170): this composition path mirrors the non-composition routing —
+    # controller/behaviors publish cmd_vel_nav and the Collision Monitor gates it
+    # (cmd_vel_in_topic: cmd_vel_nav -> cmd_vel_out_topic:
+    # piloting_mode/autonomous/cmd_vel, both from nav2_params.yaml). velocity_smoother
+    # is omitted here too (the cmd_vel filter chain is deliberately disconnected on
+    # these boats; it is also absent from lifecycle_nodes above). This path stays
+    # UNUSED in the field (use_composition=False), but is kept consistent so enabling
+    # composition cannot silently reintroduce the gating bypass.
     load_composable_nodes = GroupAction(
         condition=IfCondition(use_composition),
         actions=[
@@ -331,24 +334,15 @@ def generate_launch_description():
                         parameters=[configured_params],
                         remappings=remappings,
                     ),
-                    ComposableNode(
-                        package='nav2_velocity_smoother',
-                        plugin='nav2_velocity_smoother::VelocitySmoother',
-                        name='velocity_smoother',
-                        parameters=[configured_params],
-                        remappings=remappings
-                        + [
-                            ('cmd_vel', 'cmd_vel_nav'),
-                            ('cmd_vel_smoothed', 'piloting_mode/autonomous/cmd_vel')
-                        ],
-                    ),
+                    # velocity_smoother intentionally omitted (see NOTE above) —
+                    # mirrors its removal from the non-composition path so the
+                    # Collision Monitor is the sole publisher on the helm topic.
                     ComposableNode(
                         package='nav2_collision_monitor',
                         plugin='nav2_collision_monitor::CollisionMonitor',
                         name='collision_monitor',
                         parameters=[configured_params],
-                        remappings=remappings
-                        + [('cmd_vel', 'piloting_mode/autonomous/cmd_vel')],
+                        remappings=remappings,
                     ),
                     ComposableNode(
                         package='opennav_docking',


### PR DESCRIPTION
## Field import + review fix

Imports `ffbc57a` from `gitcloud/jazzy` (field-applied on the 2026-05-26 deployment),
then reconciles the composition path (`b213dd0`) per the `/review-code` pass.

Closes #27.

## What & why

The Phase B reflex Collision Monitor (merged in #26) was wired for the *standard* nav2
chain (`controller → velocity_smoother → cmd_vel_smoothed → monitor`). BizzyBoat runs
with the smoother deliberately disconnected, so the monitor sat on a dead input
(`cmd_vel_smoothed`, 0 publishers) while the controller published **straight to**
`piloting_mode/autonomous/cmd_vel` → `helm_manager` → FCU — **bypassing the monitor
entirely**. The reflex safety layer was active but gating nothing.

`ffbc57a` routes the controller and recovery behaviors through `cmd_vel_nav` into the
monitor and removes the unused smoother from the **non-composition** path:

- `launch/navigation_launch.py`: `controller_server` + `behavior_server` `cmd_vel`
  → `cmd_vel_nav`; `velocity_smoother` removed from `lifecycle_nodes` and its node block.
- `config/nav2_params.yaml`: `collision_monitor.cmd_vel_in_topic` → `cmd_vel_nav`.

`b213dd0` then mirrors the same rewire into the **composition** path
(`load_composable_nodes`) — because `lifecycle_nodes` is shared, `ffbc57a` alone left it
half-migrated. Drops the `velocity_smoother` ComposableNode and the no-op `cmd_vel` remap
on the composition `collision_monitor`, and corrects the inline NOTE. So
`use_composition:=True` can no longer silently reintroduce the gating bypass.

New chain (both paths):

```
controller/behaviors → /bizzy/cmd_vel_nav → collision_monitor
                      → /bizzy/piloting_mode/autonomous/cmd_vel → helm_manager → FCU
```

## Test plan

- [x] **Field-verified at the dock (2026-05-26, non-composition path)**:
      `/bizzy/piloting_mode/autonomous/cmd_vel` publisher count **9 → 1 = collision_monitor**;
      `/bizzy/cmd_vel_nav` pubs = `controller_server` + `behavior_server`, sub =
      `collision_monitor`; `velocity_smoother` gone, `/bizzy/cmd_vel_smoothed` absent;
      reflex feed survived.
- [x] **Static analysis + cross-model adversarial review** (`/review-code`, Standard): active
      path correct; composition-path inconsistency fixed in `b213dd0`.
- [ ] **Pending offline bag analysis**: confirm the boat actually slows/stops for an
      obstacle under autonomy (not yet a stated outcome).
- [ ] **Verify TODO**: confirm `base_frame_id: <tf_prefix>/base_link` substitution
      resolves at runtime (monitor active ≠ source transforms succeeding).

Sim-verify is **not** a hard gate here (operator decision); the change is a strict
improvement over a fully-bypassed monitor, baby-stepped on-water with manual/RC
override as backstop.

## Review notes

- Active (production, `use_composition=False`) path is correct and field-verified.
- Composition path reconciled in `b213dd0` (was unused, but kept consistent so a future
  `use_composition=True` can't reintroduce the bypass).
- Open suggestion (not blocking): the `velocity_smoother:` block in `nav2_params.yaml` is
  retained though the node is gone from both paths — harmless unused params, kept for the
  documented "re-enable later" path.
- No automated test (launch/param rewire); field-verified.

## Related

- Follow-up to rolker/unh_echoboats_project11#170 (closed) and #26 (Phase B).
- Part of the reflex emergency-stop work logged in rolker/unh_echoboats_project11#173
  (2026-05-26 deployment).

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
