### PR TITLE
Add support for Echoboat 240 (#3) — config 160/240 split

### DIFF
--- a/.agent/work-plans/issue-3/plan.md
+++ b/.agent/work-plans/issue-3/plan.md
@@ -1,0 +1,95 @@
+# Plan: Add support for Echoboat 240 (split generic config 160/240)
+
+## Issue
+
+https://github.com/rolker/seafloor_echoboat_project11/issues/3
+
+## Context
+
+`echoboat_project11` holds the **generic** EchoBoat config + launch. A single shared
+config set serves both hulls today, with inline comments hand-disambiguating boats —
+every per-boat edit needs cross-boat reasoning. We split it by hull model (160/240),
+selected by a launch arg. BizzyBoat (**240**) runs daily (June 4 freeze): the 240
+profile must reproduce today's behavior exactly. IzzyBoat (**160**) stays launchable.
+Per-instance config already lives in `unh_echoboats_project11/{bizzy,izzy}boat_project11`;
+those instances `IncludeLaunchDescription` the generic launches.
+
+## Approach
+
+1. **Phase 0 — spike + decide mechanism (gates the rest).** Prototype loading two param
+   files through Nav2's `RewrittenYaml` (shared base + per-model overlay) in a throwaway
+   branch; confirm per-param override works for our cases (leaf scalars, the
+   `velocity_smoother` arrays, nested `collision_monitor` polygon points, and a replaced
+   `local_costmap.plugins` list). Produce the concrete 160-vs-240 **delta table**.
+   - If the overlay plumbing is clean → **overlay** (base = today's values, so 240 = base
+     + empty/near-empty overlay = byte-equivalent; 160 overlay carries deltas).
+   - If fragile (RewrittenYaml + multi-file substitution misbehaves) → **full per-model
+     sets**, 240/ = byte-identical copy of today.
+   Record the decision + evidence in `## Implementation Notes`.
+2. **Recover 160 values via git archaeology.** For each model-specific knob, `git
+   log`/`blame` the value. Changed-for-240 knobs recover their 160 value (validated:
+   `minimum_turning_radius` 160=`3.0`; 4 `sea_surface_layer`s added for Bizzy #18 → 160 =
+   none/forward-only; `default_speed` 160=`0.75`). Never-changed-since-origin knobs
+   (`robot_radius`, footprint, `velocity_smoother` limits — all from the 2025-03 origin)
+   stay in shared base; flag any that look hull-wrong for the 240 as re-tuning follow-ups
+   (do **not** change pre-freeze).
+3. **Add `model:=160|240` arg** to the generic launch(es) (`echo_launch.py`,
+   `nav2_bringup_launch.py`); select the per-model config/overlay from it. Default `240`
+   (current behavior) to keep any direct callers safe.
+4. **Thread the arg from instances.** `bizzyboat_project11` include passes `model: '240'`;
+   `izzyboat_project11` passes `model: '160'`.
+5. **Consolidate duplicated knobs** to one home per model: hull dims (today in
+   `platform.yaml`, `echo.yaml`, footprint — 3 inconsistent values), turning radius
+   (`minimum_turning_radius`/`turn_radius`/`radius`), PID (`nav2_params` vs `echo.yaml`).
+6. **Verify 240 regression-safety**: diff effective loaded params (240 selection) against
+   today's; assert byte/param equivalence before the PR is ready.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `echoboat_project11/launch/echo_launch.py` | Add `model` arg; select per-model config |
+| `echoboat_project11/launch/nav2_bringup_launch.py` | Accept/forward `model`; load base + overlay (or per-model set) |
+| `echoboat_project11/config/**` | Split into base + `160`/`240` (mechanism per Phase 0); consolidate dup knobs |
+| `unh_echoboats_project11/bizzyboat_project11/launch/*.py` | Pass `model: '240'` on generic includes |
+| `unh_echoboats_project11/izzyboat_project11/launch/*.py` | Pass `model: '160'` on generic includes |
+| `echoboat_project11/README` / docs | Document selector + per-model values |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| A change includes its consequences | Threads the arg through both instance packages (cross-repo); consolidates duplicated knobs rather than leaving new drift. |
+| Improve incrementally | 240 unchanged (regression-safe); 160 recovered now but re-tuning candidates deferred as follow-ups, not forced pre-freeze. |
+| Test what breaks | Phase 0 spike de-risks the launch plumbing; explicit 240 effective-param equivalence check before ready. |
+| Workspace vs. project separation | Generic (echoboat) vs instance (bizzy/izzy) boundary preserved; model split lives in the generic package, instances only select. |
+| Only what's needed | One generic launch + model arg, not duplicated launch files, unless Phase 0 finds launch-level (not just param) model differences. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| Workspace ADR-0013 (progress.md vocabulary) | Yes (procedural) | `## Plan Authored` entry; later `## Local Review`/`## Integrated Review`. |
+| Project-level ADRs | No | seafloor has no `docs/decisions/`. (Onboarding gap tracked separately.) |
+
+## Consequences
+
+| If we change... | Also update... | Included? |
+|---|---|---|
+| Generic launch arg surface (`model`) | Both instance packages' includes (cross-repo, `unh_echoboats_project11`) | Yes (steps 4) |
+| Config file layout/paths | `echoboat_project11/CMakeLists.txt` install() of config dir | Yes (verify during impl) |
+| Footprint/dynamics homes (consolidation) | Any node reading the now-removed duplicate (e.g. `navigator` in `echo.yaml`) | Yes (step 5) |
+
+## Open Questions
+
+- Cross-repo PRs: the instance-launch changes land in `unh_echoboats_project11` — separate
+  PR there, or sequence with this one? (Leaning: this seafloor PR first with a back-compat
+  `240` default so instances keep working unchanged; instance PR follows.)
+- Which never-revisited knobs (e.g. `robot_radius`, footprint) are genuinely wrong for the
+  240 and worth a re-tuning follow-up vs genuinely shared — surface the candidates after
+  the delta table exists.
+
+## Estimated Scope
+
+Multiple PRs: (1) seafloor split + `model` arg with `240` default (this issue, regression-safe);
+(2) `unh_echoboats_project11` instances pass their model; (3) optional 240 re-tuning follow-ups.

--- a/.agent/work-plans/issue-3/plan.md
+++ b/.agent/work-plans/issue-3/plan.md
@@ -6,90 +6,121 @@ https://github.com/rolker/seafloor_echoboat_project11/issues/3
 
 ## Context
 
-`echoboat_project11` holds the **generic** EchoBoat config + launch. A single shared
-config set serves both hulls today, with inline comments hand-disambiguating boats —
-every per-boat edit needs cross-boat reasoning. We split it by hull model (160/240),
-selected by a launch arg. BizzyBoat (**240**) runs daily (June 4 freeze): the 240
-profile must reproduce today's behavior exactly. IzzyBoat (**160**) stays launchable.
-Per-instance config already lives in `unh_echoboats_project11/{bizzy,izzy}boat_project11`;
-those instances `IncludeLaunchDescription` the generic launches.
+`echoboat_project11` holds the **generic** EchoBoat config + launch; one shared set
+serves both hulls, hand-disambiguated by comments. BizzyBoat (**240**) runs daily
+(June 4 freeze); IzzyBoat (**160**) stays available. Per-instance config lives in
+`unh_echoboats_project11/{bizzy,izzy}boat_project11`; instances `IncludeLaunchDescription`
+the generic launches.
 
-## Approach
+## Phase 0 findings (done — git archaeology + plumbing read)
 
-1. **Phase 0 — spike + decide mechanism (gates the rest).** Prototype loading two param
-   files through Nav2's `RewrittenYaml` (shared base + per-model overlay) in a throwaway
-   branch; confirm per-param override works for our cases (leaf scalars, the
-   `velocity_smoother` arrays, nested `collision_monitor` polygon points, and a replaced
-   `local_costmap.plugins` list). Produce the concrete 160-vs-240 **delta table**.
-   - If the overlay plumbing is clean → **overlay** (base = today's values, so 240 = base
-     + empty/near-empty overlay = byte-equivalent; 160 overlay carries deltas).
-   - If fragile (RewrittenYaml + multi-file substitution misbehaves) → **full per-model
-     sets**, 240/ = byte-identical copy of today.
-   Record the decision + evidence in `## Implementation Notes`.
-2. **Recover 160 values via git archaeology.** For each model-specific knob, `git
-   log`/`blame` the value. Changed-for-240 knobs recover their 160 value (validated:
-   `minimum_turning_radius` 160=`3.0`; 4 `sea_surface_layer`s added for Bizzy #18 → 160 =
-   none/forward-only; `default_speed` 160=`0.75`). Never-changed-since-origin knobs
-   (`robot_radius`, footprint, `velocity_smoother` limits — all from the 2025-03 origin)
-   stay in shared base; flag any that look hull-wrong for the 240 as re-tuning follow-ups
-   (do **not** change pre-freeze).
-3. **Add `model:=160|240` arg** to the generic launch(es) (`echo_launch.py`,
-   `nav2_bringup_launch.py`); select the per-model config/overlay from it. Default `240`
-   (current behavior) to keep any direct callers safe.
-4. **Thread the arg from instances.** `bizzyboat_project11` include passes `model: '240'`;
-   `izzyboat_project11` passes `model: '160'`.
-5. **Consolidate duplicated knobs** to one home per model: hull dims (today in
-   `platform.yaml`, `echo.yaml`, footprint — 3 inconsistent values), turning radius
-   (`minimum_turning_radius`/`turn_radius`/`radius`), PID (`nav2_params` vs `echo.yaml`).
-6. **Verify 240 regression-safety**: diff effective loaded params (240 selection) against
-   today's; assert byte/param equivalence before the PR is ready.
+- **Timeline maps to boats**: 2025 commits = Izzy(160) era; 2026 commits = Bizzy(240) era.
+  Today the two boats run **nearly identical** generic config.
+- **The real deltas are few, and split three ways:**
+  1. **Sensor rig + reflex** (4 OAK `sea_surface_layer`s; `collision_monitor` momentum
+     polygons + `reflex_cloud`) — driven by Bizzy's camera hardware + reflex deployment,
+     **not** the hull. The 4 OAK *camera* configs already live in `bizzyboat_project11`.
+     → **instance-level, move out of generic.**
+  2. **General corrections** mislabeled as 240 changes (`minimum_turning_radius` 3.0→1.5
+     #124; pid sign-flip) — both hulls want these; don't revert for 160.
+  3. **True hull-model params** (footprint, `robot_radius`, velocity/accel/rotational
+     limits, hover) — currently **identical**: the 240 inherited Izzy's 160 values, never
+     re-tuned. Measured truth differs (160 `measurements.md`: top ~2 m/s, accel ~0.6,
+     rot ~1.5 rad/s, **turn radius 3–4 m**; 240 geometry in `bizzyboat.urdf.xacro`).
+- **Mechanism decided: layered param composition** (not full per-model file copies — the
+  delta is ~a dozen lines; duplication would re-create the friction). nav2_bringup wraps a
+  single `source_file` in `ReplaceString`→`RewrittenYaml`; we add a launch-time deep-merge
+  (we're not bound to nav2's single-file layout) that composes
+  `base + hull-model-overlay + instance-overlay` → one temp YAML → the existing chain.
+
+## Target architecture
+
+- `config/nav2_params.base.yaml` — shared nav2 algorithm/structure (BT, controller
+  plugins, planner, smoother, costmap structure, frames, collision_monitor *structure*,
+  docking). All echoboats.
+- `config/nav2_params.{160,240}.yaml` — hull-model overlay: footprint, `robot_radius`,
+  velocity/accel/rotational limits, hover, turning radius. **160** from `measurements.md`;
+  **240** geometry from `bizzyboat.urdf.xacro` + dynamics from current Bizzy-tuned values.
+- Instance overlay in `bizzyboat_project11` / `izzyboat_project11` — sensor rig
+  (`sea_surface_layer`s ← OAK suite) + reflex/collision polygons + observation sources.
+  Bizzy = 4-OAK + reflex; Izzy = forward-only / none.
+- `echo.yaml` model-specific bits (platform dims, `helm_manager.max_speed/max_yaw_speed`,
+  `navigator.robot`) follow the same base/hull-overlay split; reconcile the duplicated
+  hull-dim/turn-radius/pid homes (3 inconsistent copies today) to one each.
+
+## Approach (sequenced to protect the daily boat)
+
+1. **Composition mechanism + base/hull split, 240 ≡ today.** Add `model:=160|240` arg;
+   deep-merge base+overlay in `nav2_bringup_launch.py`; 240 overlay = today's values →
+   **zero behavior change**, regression-safe. Lands first.
+2. **Move rig/reflex to instance overlays** (behavior-neutral refactor; cross-repo to
+   `unh_echoboats_project11`). Bizzy keeps its 4-OAK + reflex via its overlay; generic
+   base loses them.
+3. **160 overlay from measurements** (Izzy not running daily → low risk).
+4. **240 re-tune from real specs** (footprint from URDF; dynamics review). **Behavior
+   change to the deployed boat → on-water re-validation; timing vs June 4 is an open
+   question below.**
 
 ## Files to Change
 
 | File | Change |
 |------|--------|
-| `echoboat_project11/launch/echo_launch.py` | Add `model` arg; select per-model config |
-| `echoboat_project11/launch/nav2_bringup_launch.py` | Accept/forward `model`; load base + overlay (or per-model set) |
-| `echoboat_project11/config/**` | Split into base + `160`/`240` (mechanism per Phase 0); consolidate dup knobs |
-| `unh_echoboats_project11/bizzyboat_project11/launch/*.py` | Pass `model: '240'` on generic includes |
-| `unh_echoboats_project11/izzyboat_project11/launch/*.py` | Pass `model: '160'` on generic includes |
-| `echoboat_project11/README` / docs | Document selector + per-model values |
+| `echoboat_project11/launch/nav2_bringup_launch.py` | `model` arg + deep-merge composition of base/hull/instance params |
+| `echoboat_project11/launch/echo_launch.py` | `model` arg; select hull overlay for `echo.yaml` bits |
+| `echoboat_project11/config/nav2_params.{base,160,240}.yaml` | Split from today's `nav2_params.yaml` |
+| `echoboat_project11/config/echo*.yaml` | Base/hull split; consolidate dup hull-dim/turn-radius/pid |
+| `unh_echoboats_project11/bizzyboat_project11/{launch,config}` | Pass `model:'240'`; own rig+reflex overlay |
+| `unh_echoboats_project11/izzyboat_project11/{launch,config}` | Pass `model:'160'`; own rig overlay (forward-only) |
+
+(Review finding folded in: `navigation_launch.py`'s `params/nav2_params.yaml` default is
+vestigial — it's always overridden by the forwarded `params_file`; no model logic there.)
 
 ## Principles Self-Check
 
 | Principle | Consideration |
 |---|---|
-| A change includes its consequences | Threads the arg through both instance packages (cross-repo); consolidates duplicated knobs rather than leaving new drift. |
-| Improve incrementally | 240 unchanged (regression-safe); 160 recovered now but re-tuning candidates deferred as follow-ups, not forced pre-freeze. |
-| Test what breaks | Phase 0 spike de-risks the launch plumbing; explicit 240 effective-param equivalence check before ready. |
-| Workspace vs. project separation | Generic (echoboat) vs instance (bizzy/izzy) boundary preserved; model split lives in the generic package, instances only select. |
-| Only what's needed | One generic launch + model arg, not duplicated launch files, unless Phase 0 finds launch-level (not just param) model differences. |
+| A change includes its consequences | Cross-repo arg threading + rig-overlay moves; consolidate the 3 duplicated hull-dim/turn-radius/pid copies rather than leave drift. |
+| Improve incrementally | Sequenced so the regression-safe mechanism lands first; behavior-changing 240 re-tune is isolated + validated last. |
+| Test what breaks | 240≡today equivalence check at step 1; on-water re-validation gates the step-4 re-tune. |
+| Workspace vs. project separation | Hull-model = generic; sensor rig/reflex = instance — the boundary the data revealed. |
+| Only what's needed | Layered overlay (small deltas) not full file duplication. |
 
 ## ADR Compliance
 
 | ADR | Triggered | How addressed |
 |---|---|---|
-| Workspace ADR-0013 (progress.md vocabulary) | Yes (procedural) | `## Plan Authored` entry; later `## Local Review`/`## Integrated Review`. |
-| Project-level ADRs | No | seafloor has no `docs/decisions/`. (Onboarding gap tracked separately.) |
+| Workspace ADR-0013 (progress.md) | Yes (procedural) | Plan Authored / Plan Review / Local / Integrated entries. |
+| Project ADRs | No | seafloor has none. |
 
 ## Consequences
 
 | If we change... | Also update... | Included? |
 |---|---|---|
-| Generic launch arg surface (`model`) | Both instance packages' includes (cross-repo, `unh_echoboats_project11`) | Yes (steps 4) |
-| Config file layout/paths | `echoboat_project11/CMakeLists.txt` install() of config dir | Yes (verify during impl) |
-| Footprint/dynamics homes (consolidation) | Any node reading the now-removed duplicate (e.g. `navigator` in `echo.yaml`) | Yes (step 5) |
+| `model` arg surface on generic launch | both instance includes (cross-repo) | Yes (steps 1–2) |
+| Move rig/reflex out of generic base | Bizzy must re-add via its overlay or lose segmentation/reflex | Yes (step 2) |
+| Config filenames/layout | `CMakeLists.txt` install() globs in all three packages | Yes (verify in impl) |
+| 240 dynamics/geometry (step 4) | on-water behavior; survey-limit assumptions (#124) | Yes — validation gate |
 
 ## Open Questions
 
-- Cross-repo PRs: the instance-launch changes land in `unh_echoboats_project11` — separate
-  PR there, or sequence with this one? (Leaning: this seafloor PR first with a back-compat
-  `240` default so instances keep working unchanged; instance PR follows.)
-- Which never-revisited knobs (e.g. `robot_radius`, footprint) are genuinely wrong for the
-  240 and worth a re-tuning follow-up vs genuinely shared — surface the candidates after
-  the delta table exists.
+- **240 re-tune timing (step 4)**: it changes the daily boat's behavior and needs on-water
+  re-validation. Land before June 4 (validate under freeze pressure) or defer the re-tune
+  to after the class, keeping 240 ≡ today's values until then? Steps 1–3 are safe either way.
+- Cross-repo PR sequencing: seafloor mechanism PR first (240≡today, back-compat default),
+  then the `unh_echoboats_project11` instance-overlay PR. Confirm.
 
 ## Estimated Scope
 
-Multiple PRs: (1) seafloor split + `model` arg with `240` default (this issue, regression-safe);
-(2) `unh_echoboats_project11` instances pass their model; (3) optional 240 re-tuning follow-ups.
+4 PRs across 2 repos: (1) seafloor composition + base/hull split (regression-safe);
+(2) `unh_echoboats` instance rig/reflex overlays + model arg; (3) 160 overlay from
+measurements; (4) 240 re-tune (behavior change, validated). Steps 1–2 are the structural
+core; 3–4 populate values.
+
+## Implementation Notes
+
+- Mechanism decision (Phase 0): layered deep-merge composition chosen over full per-model
+  file sets because the real 160/240 delta is ~a dozen lines and full duplication would
+  re-create shared-edit friction. Evidence: `git blame` shows today's config is ~95%
+  Izzy(160)-origin; the few 2026 Bizzy changes are either general corrections or
+  rig/reflex (instance-level). nav2_bringup's single-`source_file` `ReplaceString` chain
+  is fed the merged temp file, so the substitution path is unchanged.

--- a/.agent/work-plans/issue-3/progress.md
+++ b/.agent/work-plans/issue-3/progress.md
@@ -241,3 +241,14 @@ are nits / already-dispositioned / verified false.
       full implementation — `plan.md:6`
 - [ ] (dispositioned, Copilot ×2) `navigation_launch.py` base fallback omits hull params —
       pre-existing, documented intentional for the rare standalone invocation — `navigation_launch.py:95-99`
+
+### Round 2 (Copilot auto-review after the step-3 / echo.yaml pushes)
+- [x] (suggestion, Copilot) `merged_params()` non-mapping layer → low-signal `AttributeError` —
+      added `_load_layer()` (None → {} no-op; non-dict → clear RuntimeError naming the file) +
+      `test_non_mapping_overlay_raises_clear_error`. 15 pass — `param_compose.py`
+- [x] (stale) `Closes #3` thread — resolved: PR body now says "Part of #3", does not auto-close.
+- [ ] (dispositioned, recurring) `navigation_launch.py` standalone fallback omits hull params —
+      documented intentional (always overridden by `nav2_bringup_launch.py`); surfaced to Roland
+      as a separate small task if standalone launch should be fully supported — `navigation_launch.py:95-99`
+- [ ] (nit, won't-fix-now) ADR-0013 verdict vocabulary in older plan-review entries — cosmetic
+      historical entries; left for the user — `progress.md:20,27`

--- a/.agent/work-plans/issue-3/progress.md
+++ b/.agent/work-plans/issue-3/progress.md
@@ -197,6 +197,32 @@ once `izzyboat_launch.py` (in `unh_echoboats_project11`) passes `model:='160'` t
 Izzy isn't the next-deployment boat, so it's flagged for a decision rather than spawned as a
 new issue/PR. Until then Izzy gets the default (240) overlay.
 
+## Implementation — echo.yaml dead-navigator-block removal (2026-05-27)
+
+**Branch**: feature/issue-3 (PR #29). Decision (Roland): "just delete the dead block" — do
+*not* do the full echo.yaml base/hull split yet.
+
+**Finding that drove it** — verified where `echo.yaml`'s `/**/navigator:` block is actually
+consumed (Roland asked to double-check old-vs-current navigator):
+- It targets a node named `navigator` = the pre-BT **`marine_navigation`** standalone planner.
+  Its launch include in `marine_autonomy/launch/robot_core_launch.py` is **commented out**, and
+  the `marine_navigation` package **is no longer in the workspace** (only `unh_marine_navigation`'s
+  `marine_nav_*` packages exist).
+- The live navigator is **`bt_task_navigator`** (`marine_nav_bt_task_navigator`, runs
+  `run_tasks.xml`). Different node name → the `/**/navigator` params never attach to it.
+- `turn_radius` has **no consumer anywhere** in the workspace; `survey_lead_in_distance` likewise
+  (the live `lead_in_distance` in `manda_coverage/SurveyPath.cpp` is a different key/node).
+- So the plan's "3 inconsistent *live* hull/turn-radius copies" was partly wrong: the `echo.yaml`
+  `navigator.robot` copy is a **corpse**, not live drift. No reconcile + on-water validation needed.
+
+**Change**: deleted the entire `/**/navigator:` block (`echo.yaml`) — behavior-neutral (no
+consumer). Left a 2-line breadcrumb comment. The live `echo.yaml` blocks (`platform_sender`,
+`mru_transform`, `helm_manager`, `mavros`, `udp_bridge`) are untouched.
+
+**Deferred** (not this PR): the base/hull split of the live model-specific `echo.yaml` bits
+(`platform_sender` dims, `helm_manager` max_speed/yaw, `mavros` component_id). #3 stays partially
+open for that + the Izzy `model:=160` launch thread.
+
 ## Review Triage — Copilot PR #29 backlog (autonomous, 2026-05-27)
 
 Triaged the unresolved Copilot threads carried from the earlier PR #29 rounds. Two were

--- a/.agent/work-plans/issue-3/progress.md
+++ b/.agent/work-plans/issue-3/progress.md
@@ -98,8 +98,8 @@ placeholder-equal until step 3 — threading `model=160` to izzy is a step-3 ite
 - [ ] **Step 3:** real 160 values into `nav2_params.160.yaml` from
       `izzyboat_project11/measurements.md` (turn radius 3–4 m, top ~2 m/s, accel ~0.6,
       rot ~1.5 rad/s, smaller footprint) + thread `model=160` to izzy via `echo_launch.py`.
-- [ ] **Step 4:** 240 re-tune from `bizzyboat.urdf.xacro` geometry + measured dynamics
-      (behavior change → on-water validation; timing vs June 4 freeze = open question).
+- [x] **Step 4:** 240 footprint re-tuned (see Implementation entry below). Dynamics knobs
+      needed no change (already correct via #124). **On-water validation still pending.**
 - [ ] `echo.yaml` model-specific bits (platform dims, helm max_speed/yaw, navigator block,
       path_follower pid) + consolidate the duplicated hull-dim/turn-radius/pid homes (deferred).
 
@@ -108,3 +108,63 @@ placeholder-equal until step 3 — threading `model=160` to izzy is a step-3 ite
 
 **Active worktrees (not removed):** `issue-seafloor_echoboat_project11-3`,
 `issue-unh_echoboats_project11-184`.
+
+## Implementation — Step 4: 240 footprint re-tune (2026-05-27)
+
+**Branch**: feature/issue-3 (folded into PR #29 — user's call; #29 is therefore no longer
+"240 ≡ today", and the structural split + this behavior change now ship together).
+
+**What changed** (`config/nav2_params.240.yaml`):
+- `footprint` (local + global costmap): Izzy-inherited `[[1.0,0],[0.0,0.3],[-0.5,0.3],
+  [-0.5,-0.3],[0.0,-0.3],[1.0,0]]` (1.5 × 0.6 m) → `[[0.95,0.5],[0.95,-0.5],[-1.0,-0.5],
+  [-1.0,0.5]]` (~1.95 × 1.0 m bounding box of the real 240 hull).
+
+**Why this is the whole re-tune** (cross-checked vs current-corrected
+`unh_echoboats_project11/docs/bizzyboat_performance.md`, #124 §2, 7 deployments, + URDF):
+- The footprint was the only genuinely Izzy-inherited, hull-wrong value. Source:
+  `bizzyboat.urdf.xacro` — side bumpers 1.80 m @ y=±0.47 (~0.94 m beam), stern AutoNav box
+  x≈−0.99, fwd camera/rail overhang x≈+1.05 (up high; box sits under it with margin).
+  Roland chose the hull-box-+-margin option (vs include-overhang / tapered hexagon).
+- **Already correct, untouched**: `minimum_turning_radius 1.5` (matches measured ~1.5 m @
+  cruise), `behavior_server.max_rotational_vel 1.0` (matches ~0.9 rad/s peak pivot + raised
+  helm cap), `FollowPath.default_speed 1.5` in base (matches cruise 1.52 m/s). These were
+  the #124 *general* corrections, not Izzy inheritance.
+- **Vestigial**: `global_costmap.robot_radius 1.5` — ignored when a footprint polygon is set;
+  left as-is, flagged for the echo.yaml consolidation step.
+- **Deliberately not re-tuned**: `velocity_smoother` — the performance doc states it is
+  disconnected on Bizzy and re-tuning is deferred ("no action unless needed"). Out of scope.
+
+**Tests**: `test/test_param_compose.py` — added `test_240_footprint_matches_real_hull`
+(asserts ≥1.8 m × ≥0.9 m extent on both costmaps + local==global; catches a silent revert to
+the Izzy 1.5 × 0.6 footprint). Docstring updated (240 no longer byte-equals pre-split for the
+footprint). 12 passed.
+
+**⚠ Behavior change → on-water validation pending**: a bigger footprint widens planned berths
+and may reject tighter passages. Not yet runtime-tested. Recommended before PR #29 merges /
+reaches the daily boat.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-05-27 11:36 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+**Verdict**: approved
+
+**Branch**: feature/issue-3 at `4a35052` + working tree (step-4 footprint re-tune)
+**Mode**: pre-push
+**Depth**: Standard (reason: deployed boat's autonomous nav2 safety config — footprint affects collision/planning)
+**Must-fix**: 0 | **Suggestions**: 5 (1 fixed, 4 dispositioned)
+
+Covered the step-4 footprint re-tune + the previously-unreviewed step-2 cutover. Static
+analysis clean (yamllint, flake8). Both adversarial specialists ran (Claude + Copilot).
+Copilot's two "must-fix" (footprint not closed; winding CW→CCW) were **verified false
+positives** against Nav2 `FootprintCollisionChecker.footprintCost`: Nav2 closes the polygon
+itself (last→first edge) and computes max-cost over traced edges (winding-independent). Claude's
+"open ring, winding-independent" read was correct.
+
+### Findings
+- [x] (suggestion) stale `nav2_params.yaml` ref in comment — fixed → `nav2_params.base.yaml` — `navigation_launch.py:278`
+- [ ] (suggestion) `robot_radius 1.5` vestigial when footprint set — deferred to echo.yaml consolidation step — `nav2_params.240.yaml:18`
+- [ ] (suggestion) standalone-launch fallback uses rig-less base — pre-existing, documented intentional — `navigation_launch.py:95`
+- [ ] (suggestion, Copilot, won't-fix) footprint extent thresholds loose — by design (revert guard, not spec pin) — `test_param_compose.py`
+- [ ] (suggestion, Copilot) no schema validation in `deep_merge`/composed tree — step-1 mechanism, out of scope; footprint presence is tested — `param_compose.py`
+- [ ] (false positive, Copilot) footprint not closed / winding order — verified against Nav2 source; open rings correct, winding-independent — `nav2_params.240.yaml`

--- a/.agent/work-plans/issue-3/progress.md
+++ b/.agent/work-plans/issue-3/progress.md
@@ -169,6 +169,34 @@ itself (last→first edge) and computes max-cost over traced edges (winding-inde
 - [ ] (suggestion, Copilot) no schema validation in `deep_merge`/composed tree — step-1 mechanism, out of scope; footprint presence is tested — `param_compose.py`
 - [ ] (false positive, Copilot) footprint not closed / winding order — verified against Nav2 source; open rings correct, winding-independent — `nav2_params.240.yaml`
 
+## Implementation — Step 3: real 160 values + model plumbing (2026-05-27)
+
+**Branch**: feature/issue-3 (folded into PR #29, per Roland — #29 carries the whole #3 split).
+
+**`config/nav2_params.160.yaml`** — replaced the placeholder (was a copy of the 240 overlay)
+with real Izzy values:
+- footprint from `izzyboat.urdf` (hull 1.3×0.8 m + 45°-rotated pointed bow to x≈1.15) →
+  pointed-bow polygon `[[1.1,0],[0.7,0.45],[-0.6,0.45],[-0.6,-0.45],[0.7,-0.45]]` (~1.7×0.9 m).
+- dynamics from `izzyboat_project11/measurements.md`: `minimum_turning_radius 3.0` (Izzy turns
+  much wider than the 240's 1.5 — skid-steer, not vectored thrust), `max_rotational_vel 1.5`
+  (vs 240's 1.0), `rotational_acc_lim 1.2`, smoother `max_velocity [2.0,0,1.5]` / `max_accel
+  [0.6,0,1.2]` / `max_decel [-0.9,0,-1.2]`, hover `minimum_radius 3.0`.
+- **Field-estimate-grade** (measurements.md is informal foxglove-eyeball notes); Izzy is the
+  test boat, not the daily boat → review / on-water validate when Izzy next runs.
+
+**`launch/echo_launch.py`** — added a `model` arg (`choices=['160','240']`, default `240` to
+match `nav2_bringup_launch.py`) and forwards it into the nav2_bringup include. Generic launch,
+so it can't hardcode 160.
+
+**Tests**: added `test_160_hull_values_distinct_from_240` (locks turn radius 3.0 > 240's,
+max_rotational_vel 1.5, distinct footprint). 14 pass.
+
+**⬜ Cross-repo follow-up (NOT done — surfaced to Roland):** Izzy only *uses* the 160 overlay
+once `izzyboat_launch.py` (in `unh_echoboats_project11`) passes `model:='160'` to its
+`echo_launch.py` include — a one-line change. It's a different repo (can't fold into #29) and
+Izzy isn't the next-deployment boat, so it's flagged for a decision rather than spawned as a
+new issue/PR. Until then Izzy gets the default (240) overlay.
+
 ## Review Triage — Copilot PR #29 backlog (autonomous, 2026-05-27)
 
 Triaged the unresolved Copilot threads carried from the earlier PR #29 rounds. Two were

--- a/.agent/work-plans/issue-3/progress.md
+++ b/.agent/work-plans/issue-3/progress.md
@@ -168,3 +168,22 @@ itself (last→first edge) and computes max-cost over traced edges (winding-inde
 - [ ] (suggestion, Copilot, won't-fix) footprint extent thresholds loose — by design (revert guard, not spec pin) — `test_param_compose.py`
 - [ ] (suggestion, Copilot) no schema validation in `deep_merge`/composed tree — step-1 mechanism, out of scope; footprint presence is tested — `param_compose.py`
 - [ ] (false positive, Copilot) footprint not closed / winding order — verified against Nav2 source; open rings correct, winding-independent — `nav2_params.240.yaml`
+
+## Review Triage — Copilot PR #29 backlog (autonomous, 2026-05-27)
+
+Triaged the unresolved Copilot threads carried from the earlier PR #29 rounds. Two were
+genuine robustness bugs in the composition mechanism and are now fixed (this commit); the rest
+are nits / already-dispositioned / verified false.
+
+### Findings
+- [x] (must-fix, Copilot) `python3-yaml` only a `<test_depend>` but imported at launch by
+      `param_compose.py` — added `<exec_depend>python3-yaml</exec_depend>` — `package.xml`
+- [x] (must-fix, Copilot) `merged_params()` crashes on an empty/comment-only layer
+      (`yaml.safe_load`→None→`deep_merge(...,None)`) — guard with `... or {}` at all three
+      load sites; added `test_empty_instance_overlay_is_noop` (13 pass) — `param_compose.py:47-54`
+- [ ] (nit, Copilot) `approve-with-suggestions` / heading vocabulary vs ADR-0013 in older
+      plan-review entries — cosmetic, left for the user/triage-reviews — `progress.md:20,27`
+- [ ] (stale, Copilot) "`Closes #3` on a plan-only PR" — no longer applies; PR now carries the
+      full implementation — `plan.md:6`
+- [ ] (dispositioned, Copilot ×2) `navigation_launch.py` base fallback omits hull params —
+      pre-existing, documented intentional for the rare standalone invocation — `navigation_launch.py:95-99`

--- a/.agent/work-plans/issue-3/progress.md
+++ b/.agent/work-plans/issue-3/progress.md
@@ -1,0 +1,18 @@
+---
+issue: 3
+---
+
+# Issue #3 — Add support for Echoboat 240
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-05-26 18:37 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**Plan**: `.agent/work-plans/issue-3/plan.md` at `4c32efa`
+**PR**: https://github.com/rolker/seafloor_echoboat_project11/pull/29 (`[PLAN]` prefix)
+**Phases**: 3 (seafloor split + model arg; instance includes pass model; optional 240 re-tuning follow-ups)
+
+### Open questions
+- [ ] Cross-repo sequencing: instance-launch changes land in `unh_echoboats_project11` — separate PR sequenced after this one (back-compat `240` default keeps instances working meanwhile)?
+- [ ] Which never-revisited knobs (`robot_radius`, footprint, velocity limits) are genuinely wrong for the 240 and worth a re-tuning follow-up vs genuinely shared — decide after the Phase 0 delta table exists.

--- a/.agent/work-plans/issue-3/progress.md
+++ b/.agent/work-plans/issue-3/progress.md
@@ -31,3 +31,28 @@ issue: 3
 - [ ] (suggestion) Consider splitting PR1 into structure+model-arg (regression-safe) vs duplicate-knob consolidation — `plan.md` Approach step 5 / Estimated Scope
 - [ ] (suggestion) `sim_echo.yaml` is empty — note its disposition in the Phase 0 delta table — `plan.md` Approach step 1
 - Confirmed independently: nav2_bringup wraps a single `source_file` in `ReplaceString`+`ParameterFile`, so the Phase 0 overlay spike is genuinely necessary (not a gap — validates the plan).
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-05-26 20:47 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+**Verdict**: approved
+
+**Branch**: feature/issue-3 at `27d3de9`
+**Mode**: pre-push
+**Depth**: Standard (reason: deployed boat's autonomous nav2 launch/params)
+**Must-fix**: 0 | **Suggestions**: 3 (all addressed)
+
+Step 1 implemented: model-based param composition + nav2_params base/160/240 split.
+Adversarial wiring verified correct (Claude: lazy substitution resolution vs OpaqueFunction
+ordering is sound; composed temp file reaches both composition + non-composition node paths).
+Behavior preservation verified: merge(base,240) semantically identical to the pre-split
+nav2_params.yaml (279 leaf params, zero diffs). Copilot's "byte-equivalence" High = false
+positive (nav2 needs semantic, not byte, equivalence). Field watch-item resolved: gitcloud/jazzy
+== origin/jazzy (c804dfa), no unmerged nav2_params.yaml edits to lose.
+
+### Findings
+- [x] (suggestion, cross-confirmed) tempfile NamedTemporaryFile(delete=False) leak — added atexit cleanup — `param_compose.py`
+- [x] (suggestion, cross-confirmed) `navigation_launch.py` params_file default pointed at nonexistent `params/nav2_params.yaml` — repointed to `config/nav2_params.base.yaml` + clarifying comment — `navigation_launch.py:95`
+- [x] (suggestion) `model` arg lacked validation — added `choices=['160','240']` — `nav2_bringup_launch.py`
+- [ ] (carry-forward) field-reconciliation flow: when deleting generic config that field hosts also edit, confirm gitcloud is merged first (done here)

--- a/.agent/work-plans/issue-3/progress.md
+++ b/.agent/work-plans/issue-3/progress.md
@@ -16,3 +16,18 @@ issue: 3
 ### Open questions
 - [ ] Cross-repo sequencing: instance-launch changes land in `unh_echoboats_project11` — separate PR sequenced after this one (back-compat `240` default keeps instances working meanwhile)?
 - [ ] Which never-revisited knobs (`robot_radius`, footprint, velocity limits) are genuinely wrong for the 240 and worth a re-tuning follow-up vs genuinely shared — decide after the Phase 0 delta table exists.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-05-26 18:46 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context)) (in-context — author self-review)
+
+**Plan**: `.agent/work-plans/issue-3/plan.md` at `f536179`
+**PR**: https://github.com/rolker/seafloor_echoboat_project11/pull/29
+**Verdict**: approve-with-suggestions
+
+### Findings
+- [ ] (suggestion) Model hook is `nav2_bringup_launch.py:118-119` (`config/nav2_params.yaml`); `navigation_launch.py`'s `params/nav2_params.yaml` default is vestigial — drop/clarify it in the plan's file list — `plan.md` Files table
+- [ ] (suggestion) Consider splitting PR1 into structure+model-arg (regression-safe) vs duplicate-knob consolidation — `plan.md` Approach step 5 / Estimated Scope
+- [ ] (suggestion) `sim_echo.yaml` is empty — note its disposition in the Phase 0 delta table — `plan.md` Approach step 1
+- Confirmed independently: nav2_bringup wraps a single `source_file` in `ReplaceString`+`ParameterFile`, so the Phase 0 overlay spike is genuinely necessary (not a gap — validates the plan).

--- a/.agent/work-plans/issue-3/progress.md
+++ b/.agent/work-plans/issue-3/progress.md
@@ -56,3 +56,55 @@ positive (nav2 needs semantic, not byte, equivalence). Field watch-item resolved
 - [x] (suggestion, cross-confirmed) `navigation_launch.py` params_file default pointed at nonexistent `params/nav2_params.yaml` — repointed to `config/nav2_params.base.yaml` + clarifying comment — `navigation_launch.py:95`
 - [x] (suggestion) `model` arg lacked validation — added `choices=['160','240']` — `nav2_bringup_launch.py`
 - [ ] (carry-forward) field-reconciliation flow: when deleting generic config that field hosts also edit, confirm gitcloud is merged first (done here)
+
+## Implementation Status (resume — 2026-05-26 21:44 -04:00)
+
+> Not a review entry; a resume snapshot (per user request to persist state).
+
+**Done — steps 1, 2a, 2** (all on `feature/issue-3` @ `11065bd`, PR #29; + cross-repo PR #185):
+
+- **Mechanism (Phase 0 decision):** layered deep-merge composition, not full file copies.
+  `nav2_params.base.yaml` (shared) ← `nav2_params.<model>.yaml` (hull) ← optional
+  per-instance overlay (`instance_params`). Merge in `launch/param_compose.py`
+  (pure, unit-tested); `nav2_bringup_launch.py` `model:=160|240` (default 240) +
+  `instance_params` args drive an OpaqueFunction that composes → temp file → existing
+  `ReplaceString`/`RewrittenYaml` chain. Wiring verified correct (lazy substitution vs
+  OpaqueFunction ordering). 11 pytest cases (`test/test_param_compose.py`).
+- **Step 1:** split `nav2_params.yaml` → base + 160 + 240. 240 ≡ today (verified). 160 is
+  a placeholder copy of 240 (real values = step 3). Instances inherit `model=240` default.
+- **Step 2a:** added the optional `instance_params` 3rd layer (back-compat).
+- **Step 2 (cutover, atomic cross-repo):** base made rig-agnostic — sea_surface rig +
+  collision reflex response removed (gating wiring kept). BizzyBoat re-adds them via
+  `unh_echoboats_project11/bizzyboat_project11/config/nav2_overlay.yaml`; its
+  `nav_launch.py` passes `model:=240` + `instance_params:=<overlay>`.
+  → `unh_echoboats_project11#184`, branch `feature/issue-184` @ `2a04fad`, PR #185 (draft).
+  **Verified:** `base + 240 + overlay` == today's `nav2_params.yaml` (zero param diffs).
+
+**⚠ DEPLOY-TOGETHER:** PR #29 (seafloor base-reduction) and PR #185 (Bizzy overlay) must
+merge **and reach gabby together**, else BizzyBoat loses its rig/reflex in the gap.
+
+**Field entry points (verified):** Bizzy nav2 = `bizzyboat_project11/nav_launch.py` only
+(`core_launch.py` references echoboat's mavros.yaml, not nav2). Izzy nav2 = via
+`echo_launch.py` (gets no-rig base; `model` defaults to 240 but hull params are
+placeholder-equal until step 3 — threading `model=160` to izzy is a step-3 item).
+
+**Remaining:**
+- [ ] `/review-code` on PR #29 **and** PR #185 (not yet run for the step-2 cutover; it
+      relocates safety config — recommended before ready).
+- [ ] Runtime smoke test (live `ros2 launch`, needs built nav2 stack): confirm Bizzy gets
+      4 sea_surface layers + reflex polygons + intact gating; confirm Izzy's
+      `collision_monitor` launches cleanly with empty `polygons`/`observation_sources`
+      (pass-through) — **unverified at runtime**.
+- [ ] **Step 3:** real 160 values into `nav2_params.160.yaml` from
+      `izzyboat_project11/measurements.md` (turn radius 3–4 m, top ~2 m/s, accel ~0.6,
+      rot ~1.5 rad/s, smaller footprint) + thread `model=160` to izzy via `echo_launch.py`.
+- [ ] **Step 4:** 240 re-tune from `bizzyboat.urdf.xacro` geometry + measured dynamics
+      (behavior change → on-water validation; timing vs June 4 freeze = open question).
+- [ ] `echo.yaml` model-specific bits (platform dims, helm max_speed/yaw, navigator block,
+      path_follower pid) + consolidate the duplicated hull-dim/turn-radius/pid homes (deferred).
+
+**Open questions:** cross-repo sequencing (resolved: coordinated pair); 240-retune timing
+(step 4, pre- vs post-freeze).
+
+**Active worktrees (not removed):** `issue-seafloor_echoboat_project11-3`,
+`issue-unh_echoboats_project11-184`.

--- a/echoboat_project11/CMakeLists.txt
+++ b/echoboat_project11/CMakeLists.txt
@@ -6,4 +6,9 @@ find_package(marine_autonomy REQUIRED)
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
 install(DIRECTORY config DESTINATION share/${PROJECT_NAME})
 
+if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
+  ament_add_pytest_test(test_param_compose test/test_param_compose.py)
+endif()
+
 ament_package()

--- a/echoboat_project11/config/echo.yaml
+++ b/echoboat_project11/config/echo.yaml
@@ -53,49 +53,8 @@
       mav_frame: "BODY_NED"
 
 
-/**/navigator:
-  ros__parameters:
-
-    survey_lead_in_distance: 3.5
-    robot:
-      turn_radius: 4.0
-
-      max_velocity:
-        linear.x: 2.0
-        angular.z: 1.5
-
-      default_velocity:
-        linear.x: 1.5
-
-      max_acceleration:
-        linear.x: 0.75
-        angular.z: 0.8
-
-      default_acceleration:
-        linear.x: 0.7
-        angular.z: .3
-
-      default_deceleration:
-        linear.x: -0.35
-        angular.z: -0.3
-
-      max_deceleration:
-        linear.x: -0.7
-        angular.z: -0.8
-
-      footprint: "[[1.0, 0], [0.0, 0.3], [-0.5, 0.3], [-0.5, -0.3], [0.0, -0.3], [1.0, 0]]"
-      radius: 2.5
-
-    costmap:
-      global_frame: echo/map
-      robot_base_frame: echo/base_link
-      transform_tolerance: 1.0
-
-    path_follower:
-      pid:
-        Kp: 20.0
-        Ki: 0.5
-        Kd: 0.6
+# (Removed the dead /**/navigator: block — pre-BT marine_navigation node, no longer
+# launched; live navigator is bt_task_navigator. See #3 / commit msg.)
 
 # /**/s57_grids:
 #   ros__parameters:

--- a/echoboat_project11/config/nav2_params.160.yaml
+++ b/echoboat_project11/config/nav2_params.160.yaml
@@ -1,39 +1,44 @@
-# EchoBoat 160 hull-model overlay (#3).
-# PLACEHOLDER — currently identical to the 240 overlay so `model:=160` launches
-# cleanly and the composition mechanism is exercised. Real 160 values (from
-# izzyboat_project11/measurements.md: top ~2 m/s, accel ~0.6 m/s², rotation
-# ~1.5 rad/s, turn radius 3–4 m, smaller footprint) land in issue #3 step 3.
+# EchoBoat 160 hull-model overlay (#3 step 3).
+# Real Izzy(160) values, replacing the earlier placeholder copy of the 240 overlay.
+#  - footprint: from izzyboat.urdf hull (main body 1.3 x 0.8 m + a 45°-rotated
+#    pointed bow reaching x≈1.15) → pointed-bow polygon ~1.7 m x 0.9 m.
+#  - dynamics: from izzyboat_project11/measurements.md — top ~2 m/s, accel ~0.6 m/s²,
+#    powered decel ~-0.9 m/s², rotation ~1.5 rad/s max, rot accel ~1.2 rad/s²,
+#    turn radius ~3 m @1 m/s / ~4 m @2 m/s.
+# Izzy turns much wider and spins faster than the 240 (skid-steer, not vectored
+# thrust). Izzy is the TEST boat, not the daily boat; these are field-estimate-grade
+# values → review / on-water validate when Izzy next runs.
 local_costmap:
   local_costmap:
     ros__parameters:
-      footprint: "[[1.0, 0], [0.0, 0.3], [-0.5, 0.3], [-0.5, -0.3], [0.0, -0.3], [1.0, 0]]"
+      footprint: "[[1.1, 0.0], [0.7, 0.45], [-0.6, 0.45], [-0.6, -0.45], [0.7, -0.45]]"
 
 global_costmap:
   global_costmap:
     ros__parameters:
-      robot_radius: 1.5
-      footprint: "[[1.0, 0], [0.0, 0.3], [-0.5, 0.3], [-0.5, -0.3], [0.0, -0.3], [1.0, 0]]"
+      robot_radius: 1.0
+      footprint: "[[1.1, 0.0], [0.7, 0.45], [-0.6, 0.45], [-0.6, -0.45], [0.7, -0.45]]"
 
 planner_server:
   ros__parameters:
     GridBased:
-      minimum_turning_radius: 1.5
+      minimum_turning_radius: 3.0
 
 behavior_server:
   ros__parameters:
     hover:
-      minimum_radius: 2.5
+      minimum_radius: 3.0
       maximum_radius: 10.0
       maximum_speed: 1.0
-      maximum_rotation_speed: 0.75
+      maximum_rotation_speed: 1.0
       deceleration: -0.45
-    max_rotational_vel: 1.0
+    max_rotational_vel: 1.5
     min_rotational_vel: 0.4
-    rotational_acc_lim: 3.2
+    rotational_acc_lim: 1.2
 
 velocity_smoother:
   ros__parameters:
-    max_velocity: [2.75, 0.0, 0.45]
-    min_velocity: [-0.5, 0.0, -0.45]
-    max_accel: [0.8, 0.0, 0.2]
-    max_decel: [-0.45, 0.0, -0.2]
+    max_velocity: [2.0, 0.0, 1.5]
+    min_velocity: [-0.5, 0.0, -1.5]
+    max_accel: [0.6, 0.0, 1.2]
+    max_decel: [-0.9, 0.0, -1.2]

--- a/echoboat_project11/config/nav2_params.160.yaml
+++ b/echoboat_project11/config/nav2_params.160.yaml
@@ -1,0 +1,39 @@
+# EchoBoat 160 hull-model overlay (#3).
+# PLACEHOLDER — currently identical to the 240 overlay so `model:=160` launches
+# cleanly and the composition mechanism is exercised. Real 160 values (from
+# izzyboat_project11/measurements.md: top ~2 m/s, accel ~0.6 m/s², rotation
+# ~1.5 rad/s, turn radius 3–4 m, smaller footprint) land in issue #3 step 3.
+local_costmap:
+  local_costmap:
+    ros__parameters:
+      footprint: "[[1.0, 0], [0.0, 0.3], [-0.5, 0.3], [-0.5, -0.3], [0.0, -0.3], [1.0, 0]]"
+
+global_costmap:
+  global_costmap:
+    ros__parameters:
+      robot_radius: 1.5
+      footprint: "[[1.0, 0], [0.0, 0.3], [-0.5, 0.3], [-0.5, -0.3], [0.0, -0.3], [1.0, 0]]"
+
+planner_server:
+  ros__parameters:
+    GridBased:
+      minimum_turning_radius: 1.5
+
+behavior_server:
+  ros__parameters:
+    hover:
+      minimum_radius: 2.5
+      maximum_radius: 10.0
+      maximum_speed: 1.0
+      maximum_rotation_speed: 0.75
+      deceleration: -0.45
+    max_rotational_vel: 1.0
+    min_rotational_vel: 0.4
+    rotational_acc_lim: 3.2
+
+velocity_smoother:
+  ros__parameters:
+    max_velocity: [2.75, 0.0, 0.45]
+    min_velocity: [-0.5, 0.0, -0.45]
+    max_accel: [0.8, 0.0, 0.2]
+    max_decel: [-0.45, 0.0, -0.2]

--- a/echoboat_project11/config/nav2_params.240.yaml
+++ b/echoboat_project11/config/nav2_params.240.yaml
@@ -1,0 +1,38 @@
+# EchoBoat 240 hull-model overlay (#3).
+# Geometry + dynamics that differ by hull; merged over nav2_params.base.yaml at
+# launch (see nav2_bringup_launch.py). These are the values BizzyBoat (240) runs
+# today — keep byte-equivalent until a measured 240 re-tune (issue #3 step 4).
+local_costmap:
+  local_costmap:
+    ros__parameters:
+      footprint: "[[1.0, 0], [0.0, 0.3], [-0.5, 0.3], [-0.5, -0.3], [0.0, -0.3], [1.0, 0]]"
+
+global_costmap:
+  global_costmap:
+    ros__parameters:
+      robot_radius: 1.5
+      footprint: "[[1.0, 0], [0.0, 0.3], [-0.5, 0.3], [-0.5, -0.3], [0.0, -0.3], [1.0, 0]]"
+
+planner_server:
+  ros__parameters:
+    GridBased:
+      minimum_turning_radius: 1.5
+
+behavior_server:
+  ros__parameters:
+    hover:
+      minimum_radius: 2.5
+      maximum_radius: 10.0
+      maximum_speed: 1.0
+      maximum_rotation_speed: 0.75
+      deceleration: -0.45
+    max_rotational_vel: 1.0
+    min_rotational_vel: 0.4
+    rotational_acc_lim: 3.2
+
+velocity_smoother:
+  ros__parameters:
+    max_velocity: [2.75, 0.0, 0.45]
+    min_velocity: [-0.5, 0.0, -0.45]
+    max_accel: [0.8, 0.0, 0.2]
+    max_decel: [-0.45, 0.0, -0.2]

--- a/echoboat_project11/config/nav2_params.240.yaml
+++ b/echoboat_project11/config/nav2_params.240.yaml
@@ -1,17 +1,22 @@
 # EchoBoat 240 hull-model overlay (#3).
 # Geometry + dynamics that differ by hull; merged over nav2_params.base.yaml at
-# launch (see nav2_bringup_launch.py). These are the values BizzyBoat (240) runs
-# today — keep byte-equivalent until a measured 240 re-tune (issue #3 step 4).
+# launch (see nav2_bringup_launch.py).
+# Footprint re-tuned to the real 240 hull (#3 step 4): ~1.95 m x 1.0 m bounding
+# box from bizzyboat.urdf.xacro side bumpers (1.80 m @ y=±0.47), stern AutoNav
+# box (x≈-0.99), under the fwd camera/rail overhang. Replaces the Izzy-inherited
+# 1.5 x 0.6 footprint. Behavior change → on-water validation. Dynamics knobs
+# (turning radius, rotational vel) were already corrected via #124 and match the
+# current-corrected specs in unh_echoboats_project11/docs/bizzyboat_performance.md.
 local_costmap:
   local_costmap:
     ros__parameters:
-      footprint: "[[1.0, 0], [0.0, 0.3], [-0.5, 0.3], [-0.5, -0.3], [0.0, -0.3], [1.0, 0]]"
+      footprint: "[[0.95, 0.5], [0.95, -0.5], [-1.0, -0.5], [-1.0, 0.5]]"
 
 global_costmap:
   global_costmap:
     ros__parameters:
       robot_radius: 1.5
-      footprint: "[[1.0, 0], [0.0, 0.3], [-0.5, 0.3], [-0.5, -0.3], [0.0, -0.3], [1.0, 0]]"
+      footprint: "[[0.95, 0.5], [0.95, -0.5], [-1.0, -0.5], [-1.0, 0.5]]"
 
 planner_server:
   ros__parameters:

--- a/echoboat_project11/config/nav2_params.base.yaml
+++ b/echoboat_project11/config/nav2_params.base.yaml
@@ -95,7 +95,6 @@ local_costmap:
       width: 400
       height: 400
       resolution: 0.25
-      footprint: "[[1.0, 0], [0.0, 0.3], [-0.5, 0.3], [-0.5, -0.3], [0.0, -0.3], [1.0, 0]]"
       # Required build dependency: the `sea_surface_layer::SeaSurfaceLayer`
       # plugin lives in the `sea_surface_segmentation` package (sensors_ws
       # layer). Deployments using this config must have sensors_ws built —
@@ -175,8 +174,6 @@ global_costmap:
       publish_frequency: 0.5
       global_frame: <tf_prefix>/map_tide
       robot_base_frame: <tf_prefix>/base_link
-      robot_radius: 1.5
-      footprint: "[[1.0, 0], [0.0, 0.3], [-0.5, 0.3], [-0.5, -0.3], [0.0, -0.3], [1.0, 0]]"
       resolution: 1.0
       track_unknown_space: true
       rolling_window: true
@@ -242,7 +239,6 @@ planner_server:
       allow_unknown: true
       change_penalty: 0.5
       cost_penalty: 10.0
-      minimum_turning_radius: 1.5  # was 3.0; boats turn far tighter (rolker/unh_echoboats_project11#124 §2)
       debug_visualizations: false
       max_iterations: -1
       max_on_approach_iterations: -1
@@ -283,11 +279,6 @@ behavior_server:
       plugin: "nav2_behaviors::AssistedTeleop"
     hover:
       plugin: "marine_nav_behaviors::Hover"
-      minimum_radius: 2.5
-      maximum_radius: 10.0
-      maximum_speed: 1.0
-      maximum_rotation_speed: 0.75
-      deceleration: -0.45
       generate_visualization: true
 
     local_frame: <tf_prefix>/odom
@@ -295,9 +286,6 @@ behavior_server:
     robot_base_frame: <tf_prefix>/base_link
     transform_tolerance: 0.1
     simulate_ahead_time: 2.0
-    max_rotational_vel: 1.0
-    min_rotational_vel: 0.4
-    rotational_acc_lim: 3.2
     enable_stamped_cmd_vel: true
 
 waypoint_follower:
@@ -316,10 +304,6 @@ velocity_smoother:
     smoothing_frequency: 10.0
     scale_velocities: true
     feedback: "OPEN_LOOP"
-    max_velocity: [2.75, 0.0, 0.45]
-    min_velocity: [-0.5, 0.0, -0.45]
-    max_accel: [0.8, 0.0, 0.2]
-    max_decel: [-0.45, 0.0, -0.2]
     odom_topic: <robot_namespace>/odom
     odom_duration: 0.5
     deadband_velocity: [0.0, 0.0, 0.0]

--- a/echoboat_project11/config/nav2_params.base.yaml
+++ b/echoboat_project11/config/nav2_params.base.yaml
@@ -95,17 +95,9 @@ local_costmap:
       width: 400
       height: 400
       resolution: 0.25
-      # Required build dependency: the `sea_surface_layer::SeaSurfaceLayer`
-      # plugin lives in the `sea_surface_segmentation` package (sensors_ws
-      # layer). Deployments using this config must have sensors_ws built —
-      # otherwise pluginlib will fail to load the layer and the local_costmap
-      # bringup will fail hard.
-      plugins: ["chart_layer",
-                "sea_surface_layer_forward",
-                "sea_surface_layer_port",
-                "sea_surface_layer_starboard",
-                "sea_surface_layer_aft",
-                "inflation_layer"]
+      # Sensor-rig layers (e.g. sea_surface segmentation) are added per-boat via
+      # the instance overlay (instance_params); base is rig-agnostic (#3 step 2).
+      plugins: ["chart_layer", "inflation_layer"]
       inflation_layer:
         plugin: "nav2_costmap_2d::InflationLayer"
         cost_scaling_factor: 0.05
@@ -120,34 +112,6 @@ local_costmap:
         s57_grids_namespace: <robot_namespace>/s57
         chart_datum_frame: <tf_prefix>/chart_datum
         sea_surface_frame: <tf_prefix>/map_tide
-      # Four sea_surface_layer instances, one per OAK direction. Bizzy
-      # publishes on oak_forward/port/starboard/aft; boats without a
-      # given camera produce no segmentation traffic and the matching
-      # layer stays at NO_INFORMATION (silent no-op).
-      sea_surface_layer_forward:
-        plugin: "sea_surface_layer::SeaSurfaceLayer"
-        enabled: True
-        segmentation_topic: <robot_namespace>/sensors/cameras/oak_forward/segmentation
-        camera_info_topic: <robot_namespace>/sensors/cameras/oak_forward/segmentation/camera_info
-        maximum_range: 150.0
-      sea_surface_layer_port:
-        plugin: "sea_surface_layer::SeaSurfaceLayer"
-        enabled: True
-        segmentation_topic: <robot_namespace>/sensors/cameras/oak_port/segmentation
-        camera_info_topic: <robot_namespace>/sensors/cameras/oak_port/segmentation/camera_info
-        maximum_range: 150.0
-      sea_surface_layer_starboard:
-        plugin: "sea_surface_layer::SeaSurfaceLayer"
-        enabled: True
-        segmentation_topic: <robot_namespace>/sensors/cameras/oak_starboard/segmentation
-        camera_info_topic: <robot_namespace>/sensors/cameras/oak_starboard/segmentation/camera_info
-        maximum_range: 150.0
-      sea_surface_layer_aft:
-        plugin: "sea_surface_layer::SeaSurfaceLayer"
-        enabled: True
-        segmentation_topic: <robot_namespace>/sensors/cameras/oak_aft/segmentation
-        camera_info_topic: <robot_namespace>/sensors/cameras/oak_aft/segmentation/camera_info
-        maximum_range: 150.0
       obstacle_layer:
         plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: True
@@ -322,43 +286,12 @@ collision_monitor:
     source_timeout: 1.0
     base_shift_correction: True
     stop_pub_timeout: 2.0
-    # Polygons represent zone around the robot for "stop", "slowdown" and "limit" action types,
-    # and robot footprint for "approach" action type.
-    # Forward-arc zones (single forward camera), base_link x-fwd / y-port.
-    # Tuned for boat momentum: passive coast-down ~10-15 m from ~1.5 m/s
-    # cruise (#124 §2 / PR #172), so slowdown stands off well beyond stopping
-    # distance to bleed speed early; stop is last-resort. CM has no reverse
-    # action. Starting geometry — refine in sim + Phase C trigger catalog (#169).
-    polygons: ["CollisionSlowdown", "CollisionStop"]
-    CollisionSlowdown:
-      type: "polygon"
-      points: "[[20.0, 3.0], [20.0, -3.0], [0.0, -3.0], [0.0, 3.0]]"
-      action_type: "slowdown"
-      slowdown_ratio: 0.3
-      min_points: 4
-      visualize: True
-      polygon_pub_topic: "collision_monitor/slowdown_polygon"
-      enabled: True
-    CollisionStop:
-      type: "polygon"
-      points: "[[5.0, 2.0], [5.0, -2.0], [0.0, -2.0], [0.0, 2.0]]"
-      action_type: "stop"
-      min_points: 5
-      visualize: True
-      polygon_pub_topic: "collision_monitor/stop_polygon"
-      enabled: True
-    observation_sources: ["reflex_cloud"]
-    # Reflex PointCloud2 from the forward-OAK segmentation adapter
-    # (perception#17), on the canonical per-boat topic (bizzy:
-    # unh_echoboats_project11#178). Sparse (~tens of pts). Height bracket
-    # spans the projected plane (z~=0 in base_link_level) plus the pitch-
-    # induced z-shift of far points once transformed into base_link.
-    reflex_cloud:
-      type: "pointcloud"
-      topic: "collision_monitor/pointcloud"
-      min_height: -2.0
-      max_height: 2.0
-      enabled: True
+    # Reflex zones + observation sources are supplied per-boat via the instance
+    # overlay (instance_params) — they depend on the boat's sensor rig (#3 step 2).
+    # With neither (a boat without the reflex feed), the monitor is a pass-through:
+    # cmd_vel_nav → piloting_mode/autonomous/cmd_vel unchanged.
+    polygons: []
+    observation_sources: []
 
 docking_server:
   ros__parameters:

--- a/echoboat_project11/launch/echo_launch.py
+++ b/echoboat_project11/launch/echo_launch.py
@@ -31,8 +31,9 @@ def generate_launch_description():
 
   is_simulator = LaunchConfiguration('is_simulator')
 
-  # Hull model selects the nav2 per-hull param overlay (#3). Default 240 matches
-  # nav2_bringup_launch.py's own default; Izzy passes model:=160 from its instance launch.
+  # Hull model selects the nav2 per-hull param overlay (#3); default 240 matches
+  # nav2_bringup_launch.py. An instance launch can pass model:=160 — Izzy's instance-launch
+  # wiring is a pending follow-up, so until then Izzy uses the 240 default.
   model = LaunchConfiguration('model')
 
   namespace_arg = DeclareLaunchArgument(

--- a/echoboat_project11/launch/echo_launch.py
+++ b/echoboat_project11/launch/echo_launch.py
@@ -31,8 +31,16 @@ def generate_launch_description():
 
   is_simulator = LaunchConfiguration('is_simulator')
 
+  # Hull model selects the nav2 per-hull param overlay (#3). Default 240 matches
+  # nav2_bringup_launch.py's own default; Izzy passes model:=160 from its instance launch.
+  model = LaunchConfiguration('model')
+
   namespace_arg = DeclareLaunchArgument(
     "namespace", default_value=TextSubstitution(text="echo")
+  )
+
+  model_arg = DeclareLaunchArgument(
+    "model", default_value=TextSubstitution(text="240"), choices=["160", "240"]
   )
 
   enable_bridge_arg = DeclareLaunchArgument(
@@ -58,6 +66,7 @@ def generate_launch_description():
     fcu_url_arg,
     gcs_url_arg,
     is_simulator_arg,
+    model_arg,
     GroupAction(
       actions=[
         PushROSNamespace(namespace),
@@ -208,6 +217,7 @@ def generate_launch_description():
         'namespace': namespace,
         'use_namespace': 'true',
         'use_composition': 'False',
+        'model': model,
       }.items()
     )
 

--- a/echoboat_project11/launch/nav2_bringup_launch.py
+++ b/echoboat_project11/launch/nav2_bringup_launch.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import sys
 
 from ament_index_python.packages import get_package_share_directory
 
@@ -21,7 +22,9 @@ from launch.actions import (
     DeclareLaunchArgument,
     GroupAction,
     IncludeLaunchDescription,
+    OpaqueFunction,
     SetEnvironmentVariable,
+    SetLaunchConfiguration,
 )
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
@@ -30,6 +33,25 @@ from launch_ros.actions import Node
 from launch_ros.actions import PushROSNamespace
 from launch_ros.descriptions import ParameterFile
 from nav2_common.launch import ReplaceString, RewrittenYaml
+
+# param_compose.py lives alongside this launch file; add this directory to the
+# path so the import resolves both from source and from the installed share/ dir.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from param_compose import compose_merged_params  # noqa: E402
+
+
+def _compose_params(context, *args, **kwargs):
+    """OpaqueFunction: point params_file at base + per-model overlay unless one was given.
+
+    An explicitly-passed ``params_file`` is used as-is (escape hatch); otherwise
+    compose nav2_params.base.yaml + nav2_params.<model>.yaml into a temp file.
+    """
+    params_file = LaunchConfiguration('params_file').perform(context)
+    if params_file:
+        return []
+    model = LaunchConfiguration('model').perform(context)
+    cfg_dir = os.path.join(get_package_share_directory('echoboat_project11'), 'config')
+    return [SetLaunchConfiguration('params_file', compose_merged_params(cfg_dir, model))]
 
 
 def generate_launch_description():
@@ -114,10 +136,20 @@ def generate_launch_description():
         description='Use simulation (Gazebo) clock if true',
     )
 
+    declare_model_cmd = DeclareLaunchArgument(
+        'model',
+        default_value='240',
+        choices=['160', '240'],
+        description='EchoBoat hull model: selects config/nav2_params.<model>.yaml '
+        '(merged over nav2_params.base.yaml). 240 = BizzyBoat, 160 = IzzyBoat.',
+    )
+
     declare_params_file_cmd = DeclareLaunchArgument(
         'params_file',
-        default_value=os.path.join(bringup_dir, 'config', 'nav2_params.yaml'),
-        description='Full path to the ROS2 parameters file to use for all launched nodes',
+        default_value='',
+        description='Full path to a ROS2 parameters file. Empty (default) composes '
+        'nav2_params.base.yaml + the per-model overlay from `model`; set this to '
+        'override composition with an explicit file.',
     )
 
     declare_autostart_cmd = DeclareLaunchArgument(
@@ -186,12 +218,17 @@ def generate_launch_description():
     ld.add_action(declare_slam_cmd)
     ld.add_action(declare_map_yaml_cmd)
     ld.add_action(declare_use_sim_time_cmd)
+    ld.add_action(declare_model_cmd)
     ld.add_action(declare_params_file_cmd)
     ld.add_action(declare_autostart_cmd)
     ld.add_action(declare_use_composition_cmd)
     ld.add_action(declare_use_respawn_cmd)
     ld.add_action(declare_log_level_cmd)
     ld.add_action(declare_use_localization_cmd)
+
+    # Compose base + per-model params into params_file (unless one was passed),
+    # before the bringup group resolves the ReplaceString/RewrittenYaml chain.
+    ld.add_action(OpaqueFunction(function=_compose_params))
 
     # Add the actions to launch all of the navigation nodes
     ld.add_action(bringup_cmd_group)

--- a/echoboat_project11/launch/nav2_bringup_launch.py
+++ b/echoboat_project11/launch/nav2_bringup_launch.py
@@ -50,8 +50,10 @@ def _compose_params(context, *args, **kwargs):
     if params_file:
         return []
     model = LaunchConfiguration('model').perform(context)
+    instance_params = LaunchConfiguration('instance_params').perform(context)
     cfg_dir = os.path.join(get_package_share_directory('echoboat_project11'), 'config')
-    return [SetLaunchConfiguration('params_file', compose_merged_params(cfg_dir, model))]
+    composed = compose_merged_params(cfg_dir, model, instance_params or None)
+    return [SetLaunchConfiguration('params_file', composed)]
 
 
 def generate_launch_description():
@@ -144,12 +146,20 @@ def generate_launch_description():
         '(merged over nav2_params.base.yaml). 240 = BizzyBoat, 160 = IzzyBoat.',
     )
 
+    declare_instance_params_cmd = DeclareLaunchArgument(
+        'instance_params',
+        default_value='',
+        description='Optional path to a per-instance nav2 params overlay (e.g. a boat '
+        'instance package supplying its sensor rig / reflex config), merged on top of '
+        'base + the per-model overlay. Empty = no instance overlay.',
+    )
+
     declare_params_file_cmd = DeclareLaunchArgument(
         'params_file',
         default_value='',
         description='Full path to a ROS2 parameters file. Empty (default) composes '
-        'nav2_params.base.yaml + the per-model overlay from `model`; set this to '
-        'override composition with an explicit file.',
+        'nav2_params.base.yaml + the per-model overlay from `model` + the optional '
+        '`instance_params` overlay; set this to override composition with an explicit file.',
     )
 
     declare_autostart_cmd = DeclareLaunchArgument(
@@ -219,6 +229,7 @@ def generate_launch_description():
     ld.add_action(declare_map_yaml_cmd)
     ld.add_action(declare_use_sim_time_cmd)
     ld.add_action(declare_model_cmd)
+    ld.add_action(declare_instance_params_cmd)
     ld.add_action(declare_params_file_cmd)
     ld.add_action(declare_autostart_cmd)
     ld.add_action(declare_use_composition_cmd)

--- a/echoboat_project11/launch/navigation_launch.py
+++ b/echoboat_project11/launch/navigation_launch.py
@@ -275,7 +275,7 @@ def generate_launch_description():
     # NOTE (#170): this composition path mirrors the non-composition routing —
     # controller/behaviors publish cmd_vel_nav and the Collision Monitor gates it
     # (cmd_vel_in_topic: cmd_vel_nav -> cmd_vel_out_topic:
-    # piloting_mode/autonomous/cmd_vel, both from nav2_params.yaml). velocity_smoother
+    # piloting_mode/autonomous/cmd_vel, both from nav2_params.base.yaml). velocity_smoother
     # is omitted here too (the cmd_vel filter chain is deliberately disconnected on
     # these boats; it is also absent from lifecycle_nodes above). This path stays
     # UNUSED in the field (use_composition=False), but is kept consistent so enabling

--- a/echoboat_project11/launch/navigation_launch.py
+++ b/echoboat_project11/launch/navigation_launch.py
@@ -92,7 +92,10 @@ def generate_launch_description():
 
     declare_params_file_cmd = DeclareLaunchArgument(
         'params_file',
-        default_value=os.path.join(bringup_dir, 'params', 'nav2_params.yaml'),
+        # Normally overridden by nav2_bringup_launch.py, which passes the composed
+        # base+per-model params (#3). This fallback points at the shared base only
+        # (no hull-model overlay) for the rare standalone invocation.
+        default_value=os.path.join(bringup_dir, 'config', 'nav2_params.base.yaml'),
         description='Full path to the ROS2 parameters file to use for all launched nodes',
     )
 

--- a/echoboat_project11/launch/param_compose.py
+++ b/echoboat_project11/launch/param_compose.py
@@ -43,15 +43,17 @@ def merged_params(cfg_dir, model, instance_params=None):
             f"Unknown echoboat model '{model}': {overlay_path} not found "
             f"(expected nav2_params.<model>.yaml in {cfg_dir})"
         )
+    # `yaml.safe_load` returns None for an empty / comment-only file; treat such
+    # a layer as an empty (no-op) overlay rather than crashing in deep_merge.
     with open(os.path.join(cfg_dir, 'nav2_params.base.yaml')) as f:
-        merged = yaml.safe_load(f)
+        merged = yaml.safe_load(f) or {}
     with open(overlay_path) as f:
-        merged = deep_merge(merged, yaml.safe_load(f))
+        merged = deep_merge(merged, yaml.safe_load(f) or {})
     if instance_params:
         if not os.path.exists(instance_params):
             raise RuntimeError(f"instance_params file not found: {instance_params}")
         with open(instance_params) as f:
-            merged = deep_merge(merged, yaml.safe_load(f))
+            merged = deep_merge(merged, yaml.safe_load(f) or {})
     return merged
 
 

--- a/echoboat_project11/launch/param_compose.py
+++ b/echoboat_project11/launch/param_compose.py
@@ -27,6 +27,25 @@ def deep_merge(base, overlay):
     return out
 
 
+def _load_layer(path):
+    """Load one YAML param layer as a mapping.
+
+    An empty / comment-only file (``yaml.safe_load`` → ``None``) is treated as an
+    empty no-op layer. A non-mapping top level (list/scalar) is a config error and
+    raises a clear ``RuntimeError`` naming the file rather than a downstream
+    ``AttributeError`` from ``deep_merge``.
+    """
+    with open(path) as f:
+        data = yaml.safe_load(f)
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise RuntimeError(
+            f"param layer {path} must be a YAML mapping, got {type(data).__name__}"
+        )
+    return data
+
+
 def merged_params(cfg_dir, model, instance_params=None):
     """Return the merged param tree: base, then the per-model overlay, then an
     optional per-instance overlay (each later layer wins).
@@ -43,17 +62,12 @@ def merged_params(cfg_dir, model, instance_params=None):
             f"Unknown echoboat model '{model}': {overlay_path} not found "
             f"(expected nav2_params.<model>.yaml in {cfg_dir})"
         )
-    # `yaml.safe_load` returns None for an empty / comment-only file; treat such
-    # a layer as an empty (no-op) overlay rather than crashing in deep_merge.
-    with open(os.path.join(cfg_dir, 'nav2_params.base.yaml')) as f:
-        merged = yaml.safe_load(f) or {}
-    with open(overlay_path) as f:
-        merged = deep_merge(merged, yaml.safe_load(f) or {})
+    merged = _load_layer(os.path.join(cfg_dir, 'nav2_params.base.yaml'))
+    merged = deep_merge(merged, _load_layer(overlay_path))
     if instance_params:
         if not os.path.exists(instance_params):
             raise RuntimeError(f"instance_params file not found: {instance_params}")
-        with open(instance_params) as f:
-            merged = deep_merge(merged, yaml.safe_load(f) or {})
+        merged = deep_merge(merged, _load_layer(instance_params))
     return merged
 
 

--- a/echoboat_project11/launch/param_compose.py
+++ b/echoboat_project11/launch/param_compose.py
@@ -1,0 +1,56 @@
+"""Compose nav2 params from a shared base + a per-hull-model overlay (issue #3).
+
+Pure helpers (no ROS imports) so they can be unit-tested directly. The launch
+file (`nav2_bringup_launch.py`) adds this directory to ``sys.path`` and imports
+``compose_merged_params``; the test suite imports ``deep_merge`` directly.
+"""
+
+import atexit
+import os
+import tempfile
+
+import yaml
+
+
+def deep_merge(base, overlay):
+    """Recursively merge ``overlay`` into ``base``.
+
+    Dicts merge key-by-key; scalars and lists (including the footprint string and
+    velocity arrays) replace wholesale. Returns a new dict; inputs are not mutated.
+    """
+    out = dict(base)
+    for key, value in overlay.items():
+        if isinstance(value, dict) and isinstance(out.get(key), dict):
+            out[key] = deep_merge(out[key], value)
+        else:
+            out[key] = value
+    return out
+
+
+def merged_params(cfg_dir, model):
+    """Return the merged base + ``nav2_params.<model>.yaml`` param tree (a dict)."""
+    overlay_path = os.path.join(cfg_dir, f'nav2_params.{model}.yaml')
+    if not os.path.exists(overlay_path):
+        raise RuntimeError(
+            f"Unknown echoboat model '{model}': {overlay_path} not found "
+            f"(expected nav2_params.<model>.yaml in {cfg_dir})"
+        )
+    with open(os.path.join(cfg_dir, 'nav2_params.base.yaml')) as f:
+        merged = yaml.safe_load(f)
+    with open(overlay_path) as f:
+        return deep_merge(merged, yaml.safe_load(f))
+
+
+def compose_merged_params(cfg_dir, model):
+    """Merge base + per-model overlay and write to a temp file; return its path."""
+    merged = merged_params(cfg_dir, model)
+    tmp = tempfile.NamedTemporaryFile(
+        mode='w', prefix=f'nav2_params_{model}_', suffix='.yaml', delete=False
+    )
+    yaml.safe_dump(merged, tmp, default_flow_style=False, sort_keys=False)
+    tmp.close()
+    # The file must outlive composition (nav2 reads it at node startup, incl.
+    # respawns), so it can't be auto-deleted; clean it up at launch-process exit
+    # to avoid accumulating temps on long-lived field hosts.
+    atexit.register(lambda p=tmp.name: os.path.exists(p) and os.unlink(p))
+    return tmp.name

--- a/echoboat_project11/launch/param_compose.py
+++ b/echoboat_project11/launch/param_compose.py
@@ -27,8 +27,16 @@ def deep_merge(base, overlay):
     return out
 
 
-def merged_params(cfg_dir, model):
-    """Return the merged base + ``nav2_params.<model>.yaml`` param tree (a dict)."""
+def merged_params(cfg_dir, model, instance_params=None):
+    """Return the merged param tree: base, then the per-model overlay, then an
+    optional per-instance overlay (each later layer wins).
+
+    Layering order (lowest → highest precedence):
+      nav2_params.base.yaml  →  nav2_params.<model>.yaml  →  instance_params
+
+    ``instance_params`` is an absolute path (e.g. a boat-instance package's
+    overlay) or falsy to skip the third layer.
+    """
     overlay_path = os.path.join(cfg_dir, f'nav2_params.{model}.yaml')
     if not os.path.exists(overlay_path):
         raise RuntimeError(
@@ -38,12 +46,18 @@ def merged_params(cfg_dir, model):
     with open(os.path.join(cfg_dir, 'nav2_params.base.yaml')) as f:
         merged = yaml.safe_load(f)
     with open(overlay_path) as f:
-        return deep_merge(merged, yaml.safe_load(f))
+        merged = deep_merge(merged, yaml.safe_load(f))
+    if instance_params:
+        if not os.path.exists(instance_params):
+            raise RuntimeError(f"instance_params file not found: {instance_params}")
+        with open(instance_params) as f:
+            merged = deep_merge(merged, yaml.safe_load(f))
+    return merged
 
 
-def compose_merged_params(cfg_dir, model):
-    """Merge base + per-model overlay and write to a temp file; return its path."""
-    merged = merged_params(cfg_dir, model)
+def compose_merged_params(cfg_dir, model, instance_params=None):
+    """Merge base + per-model (+ optional instance) overlays to a temp file path."""
+    merged = merged_params(cfg_dir, model, instance_params)
     tmp = tempfile.NamedTemporaryFile(
         mode='w', prefix=f'nav2_params_{model}_', suffix='.yaml', delete=False
     )

--- a/echoboat_project11/package.xml
+++ b/echoboat_project11/package.xml
@@ -19,6 +19,9 @@
   <exec_depend>echo_helm</exec_depend>
   <exec_depend>ros2launch</exec_depend>
 
+  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>python3-yaml</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/echoboat_project11/package.xml
+++ b/echoboat_project11/package.xml
@@ -18,6 +18,8 @@
   <exec_depend>nav2_bringup</exec_depend>
   <exec_depend>echo_helm</exec_depend>
   <exec_depend>ros2launch</exec_depend>
+  <!-- param_compose.py imports yaml at launch time (composed by nav2_bringup_launch.py) -->
+  <exec_depend>python3-yaml</exec_depend>
 
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>python3-yaml</test_depend>

--- a/echoboat_project11/test/test_param_compose.py
+++ b/echoboat_project11/test/test_param_compose.py
@@ -1,0 +1,94 @@
+"""Tests for the nav2 base + per-hull-model param composition (issue #3).
+
+Locks the composition invariants: the shared base carries no hull-model knobs,
+the per-model overlays supply them, and the merge reconstructs a complete param
+tree. The one-time check that merge(base, 240) == the pre-split nav2_params.yaml
+was verified at split time (git history preserves the original); these tests
+guard the structure going forward.
+"""
+
+import os
+import sys
+
+import pytest
+import yaml
+
+_PKG = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_LAUNCH = os.path.join(_PKG, 'launch')
+_CONFIG = os.path.join(_PKG, 'config')
+sys.path.insert(0, _LAUNCH)
+
+from param_compose import deep_merge, merged_params  # noqa: E402
+
+
+def _lc(params):
+    return params['local_costmap']['local_costmap']['ros__parameters']
+
+
+def _gc(params):
+    return params['global_costmap']['global_costmap']['ros__parameters']
+
+
+# --- deep_merge semantics ---
+
+def test_deep_merge_recurses_dicts():
+    base = {'a': {'x': 1, 'y': 2}}
+    overlay = {'a': {'y': 20, 'z': 30}}
+    assert deep_merge(base, overlay) == {'a': {'x': 1, 'y': 20, 'z': 30}}
+
+
+def test_deep_merge_replaces_scalars_and_lists():
+    base = {'v': [1, 2, 3], 's': 'old'}
+    overlay = {'v': [9], 's': 'new'}
+    assert deep_merge(base, overlay) == {'v': [9], 's': 'new'}
+
+
+def test_deep_merge_does_not_mutate_inputs():
+    base = {'a': {'x': 1}}
+    overlay = {'a': {'y': 2}}
+    deep_merge(base, overlay)
+    assert base == {'a': {'x': 1}}
+
+
+# --- base carries no hull-model knobs ---
+
+def test_base_omits_hull_knobs():
+    with open(os.path.join(_CONFIG, 'nav2_params.base.yaml')) as f:
+        base = yaml.safe_load(f)
+    assert 'footprint' not in _lc(base)
+    assert 'footprint' not in _gc(base)
+    assert 'robot_radius' not in _gc(base)
+    bs = base['behavior_server']['ros__parameters']
+    assert 'max_rotational_vel' not in bs
+    assert 'minimum_radius' not in bs['hover']
+    assert 'max_velocity' not in base['velocity_smoother']['ros__parameters']
+    assert 'minimum_turning_radius' not in base['planner_server']['ros__parameters']['GridBased']
+
+
+# --- merged 240 carries today's values ---
+
+def test_merged_240_hull_values():
+    p = merged_params(_CONFIG, '240')
+    assert _gc(p)['robot_radius'] == 1.5
+    assert 'footprint' in _lc(p) and 'footprint' in _gc(p)
+    assert p['planner_server']['ros__parameters']['GridBased']['minimum_turning_radius'] == 1.5
+    assert p['velocity_smoother']['ros__parameters']['max_velocity'] == [2.75, 0.0, 0.45]
+    bs = p['behavior_server']['ros__parameters']
+    assert bs['max_rotational_vel'] == 1.0
+    assert bs['hover']['maximum_speed'] == 1.0
+    # shared base params survive the merge
+    assert p['controller_server']['ros__parameters']['controller_frequency'] == 5.0
+
+
+# --- merged 160 is well-formed (placeholder values until step 3) ---
+
+def test_merged_160_wellformed():
+    p = merged_params(_CONFIG, '160')
+    assert 'footprint' in _gc(p)
+    assert 'robot_radius' in _gc(p)
+    assert 'max_velocity' in p['velocity_smoother']['ros__parameters']
+
+
+def test_unknown_model_raises():
+    with pytest.raises(RuntimeError):
+        merged_params(_CONFIG, '999')

--- a/echoboat_project11/test/test_param_compose.py
+++ b/echoboat_project11/test/test_param_compose.py
@@ -118,3 +118,18 @@ def test_no_instance_overlay_matches_two_layer():
 def test_missing_instance_overlay_raises():
     with pytest.raises(RuntimeError):
         merged_params(_CONFIG, '240', '/nonexistent/instance.yaml')
+
+
+# --- base is rig-agnostic; sensor rig + reflex come from the instance overlay (#3 step 2) ---
+
+def test_base_has_no_sensor_rig_or_reflex():
+    with open(os.path.join(_CONFIG, 'nav2_params.base.yaml')) as f:
+        base = yaml.safe_load(f)
+    lc = _lc(base)
+    assert lc['plugins'] == ['chart_layer', 'inflation_layer']
+    assert not [k for k in lc if 'sea_surface' in k]
+    cm = base['collision_monitor']['ros__parameters']
+    # gating wiring stays; reflex zones/sources move to the instance overlay
+    assert cm['cmd_vel_in_topic'] == 'cmd_vel_nav'
+    assert cm['polygons'] == []
+    assert cm['observation_sources'] == []

--- a/echoboat_project11/test/test_param_compose.py
+++ b/echoboat_project11/test/test_param_compose.py
@@ -2,11 +2,13 @@
 
 Locks the composition invariants: the shared base carries no hull-model knobs,
 the per-model overlays supply them, and the merge reconstructs a complete param
-tree. The one-time check that merge(base, 240) == the pre-split nav2_params.yaml
-was verified at split time (git history preserves the original); these tests
-guard the structure going forward.
+tree. merge(base, 240) reproduced the pre-split nav2_params.yaml byte-for-byte at
+split time (git history preserves the original) — except the 240 footprint, which
+was subsequently re-tuned to the real hull (#3 step 4), so that equality no longer
+holds for the footprint alone. These tests guard the structure going forward.
 """
 
+import ast
 import os
 import sys
 
@@ -67,6 +69,14 @@ def test_base_omits_hull_knobs():
 
 # --- merged 240 carries today's values ---
 
+def _footprint_extent(footprint_str):
+    """Bounding-box (length_x, width_y) of a nav2 footprint polygon string."""
+    pts = ast.literal_eval(footprint_str)
+    xs = [p[0] for p in pts]
+    ys = [p[1] for p in pts]
+    return max(xs) - min(xs), max(ys) - min(ys)
+
+
 def test_merged_240_hull_values():
     p = merged_params(_CONFIG, '240')
     assert _gc(p)['robot_radius'] == 1.5
@@ -81,6 +91,19 @@ def test_merged_240_hull_values():
 
 
 # --- merged 160 is well-formed (placeholder values until step 3) ---
+
+def test_240_footprint_matches_real_hull():
+    """240 footprint was re-tuned to the real hull (#3 step 4): ~1.95 x 1.0 m
+    from bizzyboat.urdf.xacro. Guards against a silent revert to the inherited
+    Izzy 1.5 x 0.6 footprint (which would understate the deployed boat's size)."""
+    p = merged_params(_CONFIG, '240')
+    for footprint in (_lc(p)['footprint'], _gc(p)['footprint']):
+        length, width = _footprint_extent(footprint)
+        assert length >= 1.8, f'240 footprint too short ({length:.2f} m) — Izzy hull?'
+        assert width >= 0.9, f'240 footprint too narrow ({width:.2f} m) — Izzy hull?'
+    # local and global costmaps share one hull footprint
+    assert _lc(p)['footprint'] == _gc(p)['footprint']
+
 
 def test_merged_160_wellformed():
     p = merged_params(_CONFIG, '160')

--- a/echoboat_project11/test/test_param_compose.py
+++ b/echoboat_project11/test/test_param_compose.py
@@ -138,6 +138,14 @@ def test_no_instance_overlay_matches_two_layer():
     assert merged_params(_CONFIG, '240', None) == merged_params(_CONFIG, '240')
 
 
+def test_empty_instance_overlay_is_noop(tmp_path):
+    """An empty / comment-only overlay (yaml.safe_load -> None) must merge as a
+    no-op, not crash in deep_merge."""
+    empty = tmp_path / 'empty.yaml'
+    empty.write_text('# only a comment\n')
+    assert merged_params(_CONFIG, '240', str(empty)) == merged_params(_CONFIG, '240')
+
+
 def test_missing_instance_overlay_raises():
     with pytest.raises(RuntimeError):
         merged_params(_CONFIG, '240', '/nonexistent/instance.yaml')

--- a/echoboat_project11/test/test_param_compose.py
+++ b/echoboat_project11/test/test_param_compose.py
@@ -112,6 +112,22 @@ def test_merged_160_wellformed():
     assert 'max_velocity' in p['velocity_smoother']['ros__parameters']
 
 
+def test_160_hull_values_distinct_from_240():
+    """Step 3: the 160 overlay carries real Izzy values (not the placeholder copy of
+    240). Izzy turns wider and spins faster than the 240 — lock those deltas so the
+    overlay can't silently regress to the 240's vectored-thrust values."""
+    p160 = merged_params(_CONFIG, '160')
+    p240 = merged_params(_CONFIG, '240')
+    # Izzy's planned turning radius is much larger than the 240's (skid-steer).
+    assert p160['planner_server']['ros__parameters']['GridBased']['minimum_turning_radius'] == 3.0
+    assert (p160['planner_server']['ros__parameters']['GridBased']['minimum_turning_radius']
+            > p240['planner_server']['ros__parameters']['GridBased']['minimum_turning_radius'])
+    # Izzy's max yaw rate (1.5 rad/s) exceeds the 240's vectored-thrust cap (1.0).
+    assert p160['behavior_server']['ros__parameters']['max_rotational_vel'] == 1.5
+    # 160 footprint is the Izzy hull, distinct from the 240 box.
+    assert _lc(p160)['footprint'] != _lc(p240)['footprint']
+
+
 def test_unknown_model_raises():
     with pytest.raises(RuntimeError):
         merged_params(_CONFIG, '999')

--- a/echoboat_project11/test/test_param_compose.py
+++ b/echoboat_project11/test/test_param_compose.py
@@ -162,6 +162,15 @@ def test_empty_instance_overlay_is_noop(tmp_path):
     assert merged_params(_CONFIG, '240', str(empty)) == merged_params(_CONFIG, '240')
 
 
+def test_non_mapping_overlay_raises_clear_error(tmp_path):
+    """A non-mapping top-level layer (list/scalar) raises a clear RuntimeError that
+    names the file, not a low-signal AttributeError from deep_merge."""
+    bad = tmp_path / 'bad.yaml'
+    bad.write_text('- not\n- a\n- mapping\n')
+    with pytest.raises(RuntimeError, match='must be a YAML mapping'):
+        merged_params(_CONFIG, '240', str(bad))
+
+
 def test_missing_instance_overlay_raises():
     with pytest.raises(RuntimeError):
         merged_params(_CONFIG, '240', '/nonexistent/instance.yaml')

--- a/echoboat_project11/test/test_param_compose.py
+++ b/echoboat_project11/test/test_param_compose.py
@@ -92,3 +92,29 @@ def test_merged_160_wellformed():
 def test_unknown_model_raises():
     with pytest.raises(RuntimeError):
         merged_params(_CONFIG, '999')
+
+
+# --- optional instance overlay (third layer) ---
+
+def test_instance_overlay_overrides_model(tmp_path):
+    overlay = tmp_path / 'instance.yaml'
+    overlay.write_text(
+        'global_costmap:\n'
+        '  global_costmap:\n'
+        '    ros__parameters:\n'
+        '      robot_radius: 9.9\n'
+    )
+    p = merged_params(_CONFIG, '240', str(overlay))
+    # instance layer wins over the model overlay's robot_radius
+    assert _gc(p)['robot_radius'] == 9.9
+    # untouched model/base values survive
+    assert p['controller_server']['ros__parameters']['controller_frequency'] == 5.0
+
+
+def test_no_instance_overlay_matches_two_layer():
+    assert merged_params(_CONFIG, '240', None) == merged_params(_CONFIG, '240')
+
+
+def test_missing_instance_overlay_raises():
+    with pytest.raises(RuntimeError):
+        merged_params(_CONFIG, '240', '/nonexistent/instance.yaml')


### PR DESCRIPTION
Part of #3 (intentionally does **not** close it — the full `echo.yaml` base/hull split and the Izzy `model:=160` launch thread remain; tracked on #3).

> ## ⚙️ Implementation status — updated 2026-05-27
>
> | Step | State |
> |---|---|
> | 1 — composition mechanism + base/160/240 split | ✅ in #29 |
> | 2 / 2a — base rig-agnostic + instance overlay layer | ✅ in #29 (paired with `unh_echoboats_project11` **#185**) |
> | 4 — 240 footprint re-tune (Izzy-inherited → real hull) | ✅ in #29 |
> | 3 — real Izzy 160 overlay + `model` arg plumbing in `echo_launch.py` | ✅ in #29 |
> | Copilot-backlog hardening (PyYAML exec_dep, empty-overlay guard) | ✅ in #29 |
> | `echo.yaml` dead `/**/navigator:` block removed | ✅ in #29 |
> | **Deferred (not in #29):** full `echo.yaml` base/hull split of live bits; Izzy `model:=160` in `izzyboat_launch.py` (cross-repo) | ⬜ #3 stays open |
>
> **⚠️ Not "240 ≡ today":** the 240 footprint changed → **on-water validation pending**, tracked on `unh_echoboats_project11` **#186**.
> **🔗 Deploy-together** with **#185** (BizzyBoat rig/reflex overlay).
> **Reviews:** pre-push `/review-code` done; nothing merged — all merges await human review.

# Plan: Add support for Echoboat 240 (split generic config 160/240)

## Issue

https://github.com/rolker/seafloor_echoboat_project11/issues/3

## Context

`echoboat_project11` holds the **generic** EchoBoat config + launch; one shared set
serves both hulls, hand-disambiguated by comments. BizzyBoat (**240**) runs daily
(June 4 freeze); IzzyBoat (**160**) stays available. Per-instance config lives in
`unh_echoboats_project11/{bizzy,izzy}boat_project11`; instances `IncludeLaunchDescription`
the generic launches.

## Phase 0 findings (done — git archaeology + plumbing read)

- **Timeline maps to boats**: 2025 commits = Izzy(160) era; 2026 commits = Bizzy(240) era.
  Today the two boats run **nearly identical** generic config.
- **The real deltas are few, and split three ways:**
  1. **Sensor rig + reflex** (4 OAK `sea_surface_layer`s; `collision_monitor` momentum
     polygons + `reflex_cloud`) — driven by Bizzy's camera hardware + reflex deployment,
     **not** the hull. The 4 OAK *camera* configs already live in `bizzyboat_project11`.
     → **instance-level, move out of generic.**
  2. **General corrections** mislabeled as 240 changes (`minimum_turning_radius` 3.0→1.5
     #124; pid sign-flip) — both hulls want these; don't revert for 160.
  3. **True hull-model params** (footprint, `robot_radius`, velocity/accel/rotational
     limits, hover) — currently **identical**: the 240 inherited Izzy's 160 values, never
     re-tuned. Measured truth differs (160 `measurements.md`: top ~2 m/s, accel ~0.6,
     rot ~1.5 rad/s, **turn radius 3–4 m**; 240 geometry in `bizzyboat.urdf.xacro`).
- **Mechanism decided: layered param composition** (not full per-model file copies — the
  delta is ~a dozen lines; duplication would re-create the friction). nav2_bringup wraps a
  single `source_file` in `ReplaceString`→`RewrittenYaml`; we add a launch-time deep-merge
  (we're not bound to nav2's single-file layout) that composes
  `base + hull-model-overlay + instance-overlay` → one temp YAML → the existing chain.

## Target architecture

- `config/nav2_params.base.yaml` — shared nav2 algorithm/structure (BT, controller
  plugins, planner, smoother, costmap structure, frames, collision_monitor *structure*,
  docking). All echoboats.
- `config/nav2_params.{160,240}.yaml` — hull-model overlay: footprint, `robot_radius`,
  velocity/accel/rotational limits, hover, turning radius. **160** from `measurements.md`;
  **240** geometry from `bizzyboat.urdf.xacro` + dynamics from current Bizzy-tuned values.
- Instance overlay in `bizzyboat_project11` / `izzyboat_project11` — sensor rig
  (`sea_surface_layer`s ← OAK suite) + reflex/collision polygons + observation sources.
  Bizzy = 4-OAK + reflex; Izzy = forward-only / none.
- `echo.yaml` model-specific bits (platform dims, `helm_manager.max_speed/max_yaw_speed`,
  `navigator.robot`) follow the same base/hull-overlay split; reconcile the duplicated
  hull-dim/turn-radius/pid homes (3 inconsistent copies today) to one each.

## Approach (sequenced to protect the daily boat)

1. **Composition mechanism + base/hull split, 240 ≡ today.** Add `model:=160|240` arg;
   deep-merge base+overlay in `nav2_bringup_launch.py`; 240 overlay = today's values →
   **zero behavior change**, regression-safe. Lands first.
2. **Move rig/reflex to instance overlays** (behavior-neutral refactor; cross-repo to
   `unh_echoboats_project11`). Bizzy keeps its 4-OAK + reflex via its overlay; generic
   base loses them.
3. **160 overlay from measurements** (Izzy not running daily → low risk).
4. **240 re-tune from real specs** (footprint from URDF; dynamics review). **Behavior
   change to the deployed boat → on-water re-validation; timing vs June 4 is an open
   question below.**

## Files to Change

| File | Change |
|------|--------|
| `echoboat_project11/launch/nav2_bringup_launch.py` | `model` arg + deep-merge composition of base/hull/instance params |
| `echoboat_project11/launch/echo_launch.py` | `model` arg; select hull overlay for `echo.yaml` bits |
| `echoboat_project11/config/nav2_params.{base,160,240}.yaml` | Split from today's `nav2_params.yaml` |
| `echoboat_project11/config/echo*.yaml` | Base/hull split; consolidate dup hull-dim/turn-radius/pid |
| `unh_echoboats_project11/bizzyboat_project11/{launch,config}` | Pass `model:'240'`; own rig+reflex overlay |
| `unh_echoboats_project11/izzyboat_project11/{launch,config}` | Pass `model:'160'`; own rig overlay (forward-only) |

(Review finding folded in: `navigation_launch.py`'s `params/nav2_params.yaml` default is
vestigial — it's always overridden by the forwarded `params_file`; no model logic there.)

## Principles Self-Check

| Principle | Consideration |
|---|---|
| A change includes its consequences | Cross-repo arg threading + rig-overlay moves; consolidate the 3 duplicated hull-dim/turn-radius/pid copies rather than leave drift. |
| Improve incrementally | Sequenced so the regression-safe mechanism lands first; behavior-changing 240 re-tune is isolated + validated last. |
| Test what breaks | 240≡today equivalence check at step 1; on-water re-validation gates the step-4 re-tune. |
| Workspace vs. project separation | Hull-model = generic; sensor rig/reflex = instance — the boundary the data revealed. |
| Only what's needed | Layered overlay (small deltas) not full file duplication. |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| Workspace ADR-0013 (progress.md) | Yes (procedural) | Plan Authored / Plan Review / Local / Integrated entries. |
| Project ADRs | No | seafloor has none. |

## Consequences

| If we change... | Also update... | Included? |
|---|---|---|
| `model` arg surface on generic launch | both instance includes (cross-repo) | Yes (steps 1–2) |
| Move rig/reflex out of generic base | Bizzy must re-add via its overlay or lose segmentation/reflex | Yes (step 2) |
| Config filenames/layout | `CMakeLists.txt` install() globs in all three packages | Yes (verify in impl) |
| 240 dynamics/geometry (step 4) | on-water behavior; survey-limit assumptions (#124) | Yes — validation gate |

## Open Questions

- **240 re-tune timing (step 4)**: it changes the daily boat's behavior and needs on-water
  re-validation. Land before June 4 (validate under freeze pressure) or defer the re-tune
  to after the class, keeping 240 ≡ today's values until then? Steps 1–3 are safe either way.
- Cross-repo PR sequencing: seafloor mechanism PR first (240≡today, back-compat default),
  then the `unh_echoboats_project11` instance-overlay PR. Confirm.

## Estimated Scope

4 PRs across 2 repos: (1) seafloor composition + base/hull split (regression-safe);
(2) `unh_echoboats` instance rig/reflex overlays + model arg; (3) 160 overlay from
measurements; (4) 240 re-tune (behavior change, validated). Steps 1–2 are the structural
core; 3–4 populate values.

## Implementation Notes

- Mechanism decision (Phase 0): layered deep-merge composition chosen over full per-model
  file sets because the real 160/240 delta is ~a dozen lines and full duplication would
  re-create shared-edit friction. Evidence: `git blame` shows today's config is ~95%
  Izzy(160)-origin; the few 2026 Bizzy changes are either general corrections or
  rig/reflex (instance-level). nav2_bringup's single-`source_file` `ReplaceString` chain
  is fed the merged temp file, so the substitution path is unchanged.


