### PR TITLE
Retire stale hover.deceleration param from nav2 config

### DIFF
--- a/echoboat_project11/config/nav2_params.yaml
+++ b/echoboat_project11/config/nav2_params.yaml
@@ -287,7 +287,6 @@ behavior_server:
       maximum_radius: 10.0
       maximum_speed: 1.0
       maximum_rotation_speed: 0.75
-      deceleration: -0.45
       generate_visualization: true
 
     local_frame: <tf_prefix>/odom


### PR DESCRIPTION
Removes the stale `hover.deceleration: -0.45` line under `behavior_server.hover`.

The `marine_nav_behaviors::Hover` behavior no longer declares or reads `hover.deceleration` (retired in rolker/unh_marine_navigation#33 — it was declared-and-read-but-never-used). Momentum projection now lives in the navigator-level `bt_task_navigator.default_deceleration` (default `-0.45`, the same value this config set), so station-keeping behavior is unchanged. With the parameter undeclared in the node, this YAML line was an ignored override.

Safe in either merge order relative to #33: the current deployed code doesn't use the param either, so removal has no runtime effect.

Closes #30
Part of rolker/unh_marine_navigation#33

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
