### PR TITLE
nav: gate non-composed group with UnlessCondition, not eval (#32)

### DIFF
--- a/.agent/work-plans/issue-32/progress.md
+++ b/.agent/work-plans/issue-32/progress.md
@@ -1,0 +1,28 @@
+---
+issue: 32
+---
+
+# Issue #32 — navigation_launch.py: eval-based use_composition condition crashes on lowercase booleans (use UnlessCondition)
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-05-27 20:16 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+**Verdict**: approved
+
+**Branch**: feature/issue-32 at `f60595d`
+**Mode**: pre-push
+**Depth**: Light (reason: 4 lines, 2 launch files, low risk)
+**Must-fix**: 0 | **Suggestions**: 0
+
+### Findings
+- [ ] No issues found. LGTM.
+
+Static analysis (flake8, ament max-line-length=99): findings only on
+untouched pre-existing lines; touched lines clean; no F401 unused-import.
+Fresh-context adversarial sub-agent: confirmed UnlessCondition is
+semantically equivalent for all valid booleans, the composed/non-composed
+halves remain mutually exclusive and exhaustive (line 131 vs 284), imports
+consistent, and loud failure on truly-invalid input preserved. Behavior
+verified empirically (false/False/true/True/0/1) and old eval path
+reproduced the NameError.

--- a/echoboat_project11/launch/nav2_bringup_launch.py
+++ b/echoboat_project11/launch/nav2_bringup_launch.py
@@ -28,7 +28,7 @@ from launch.actions import (
 )
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration, PythonExpression
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 from launch_ros.actions import PushROSNamespace
 from launch_ros.descriptions import ParameterFile

--- a/echoboat_project11/launch/navigation_launch.py
+++ b/echoboat_project11/launch/navigation_launch.py
@@ -18,8 +18,8 @@ from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, GroupAction, SetEnvironmentVariable
-from launch.conditions import IfCondition
-from launch.substitutions import LaunchConfiguration, PythonExpression
+from launch.conditions import IfCondition, UnlessCondition
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import LoadComposableNodes, SetParameter
 from launch_ros.actions import Node
 from launch_ros.actions import LifecycleNode
@@ -128,7 +128,7 @@ def generate_launch_description():
     )
 
     load_nodes = GroupAction(
-        condition=IfCondition(PythonExpression(['not ', use_composition])),
+        condition=UnlessCondition(use_composition),
         actions=[
             SetParameter('use_sim_time', use_sim_time),
             LifecycleNode(


### PR DESCRIPTION
## What

Replace the `eval`-based launch condition that gates the non-composed Nav2 node group with `UnlessCondition`, which evaluates booleans case-insensitively and never `eval`s.

```diff
- condition=IfCondition(PythonExpression(['not ', use_composition])),
+ condition=UnlessCondition(use_composition),
```

Plus: add `UnlessCondition` to the `launch.conditions` import, drop the now-unused `PythonExpression` import in `navigation_launch.py`, and remove a pre-existing dead `PythonExpression` import in `nav2_bringup_launch.py`.

## Why

`PythonExpression` runs `eval()` on its literal text. When a caller passes a non-Python-literal boolean such as `'false'` (lowercase), `eval('not false')` raises:

```
NameError: name 'false' is not defined. Did you mean: 'False'?
```

This crashed `ros2 launch bizzyboat_project11 nav_launch.py` on gabby during a field smoke test (2026-05-27) after `unh_echoboats_project11` PR #185 lowercased the `use_composition` arg it passes down through `nav2_bringup_launch.py`. The launch arg reaches this condition several includes deep, so lowercasing it "for repo consistency" was not safe.

`UnlessCondition` uses launch's condition evaluator (`true/false/1/0`, case-insensitive), removing the `eval` entirely. Any boolean spelling now works, and the downstream lowercase value becomes correct rather than a landmine.

## Verification

- Empirically evaluated `UnlessCondition(use_composition)` for `false/False/true/True/0/1`: non-composed group runs iff composition is off; composed path (`IfCondition(use_composition)`, line 284) unchanged. Old eval path reproduces the `NameError`.
- flake8 (ament, max-line-length=99) on changed files: clean on touched lines; no unused-import findings.
- Fresh-context adversarial sub-agent review: confirmed semantic equivalence for all valid booleans, the two halves remain mutually exclusive and exhaustive, imports consistent, and loud failure on genuinely invalid input preserved. No must-fix, no suggestions.

## Test plan

- [ ] `ros2 launch bizzyboat_project11 nav_launch.py` (which passes `use_composition:='false'`) reaches node spawn without the `NameError`.
- [ ] `use_composition:=true` still loads the `nav2_container` composable path.

Closes #32

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
