### PR TITLE
config: SeaSurfaceRelayLayer in global_costmap base (#34)

### DIFF
--- a/echoboat_project11/config/nav2_params.base.yaml
+++ b/echoboat_project11/config/nav2_params.base.yaml
@@ -152,7 +152,7 @@ global_costmap:
       sea_surface_relay:
         plugin: "sea_surface_layer::SeaSurfaceRelayLayer"
         enabled: True
-        topic: sea_surface/lethal_grid
+        topic: <robot_namespace>/sea_surface/lethal_grid
       chart_layer:
         plugin: "s57_layer::S57Layer"
         enabled: True

--- a/echoboat_project11/config/nav2_params.base.yaml
+++ b/echoboat_project11/config/nav2_params.base.yaml
@@ -144,7 +144,15 @@ global_costmap:
       width: 4000
       height: 4000
       # plugins: ["chart_layer", "obstacle_layer", "inflation_layer"]
-      plugins: ["chart_layer", "inflation_layer"]
+      # `sea_surface_relay` stamps lethal cells published by the local-costmap
+      # SeaSurfaceLayer (see rolker/unh_marine_perception#20). Producer-side
+      # publishing is opt-in via the local-costmap layer's `published_topic`
+      # parameter — when no producer is wired, the relay is a silent no-op.
+      plugins: ["chart_layer", "sea_surface_relay", "inflation_layer"]
+      sea_surface_relay:
+        plugin: "sea_surface_layer::SeaSurfaceRelayLayer"
+        enabled: True
+        topic: sea_surface/lethal_grid
       chart_layer:
         plugin: "s57_layer::S57Layer"
         enabled: True


### PR DESCRIPTION
## Summary

- Adds `sea_surface_relay` (`sea_surface_layer::SeaSurfaceRelayLayer`) to
  `global_costmap.plugins` in `echoboat_project11/config/nav2_params.base.yaml`
  so the global plan sees sea-surface lethal cells without re-running the
  segmentation projection.
- Subscribes to `sea_surface/lethal_grid`; a silent no-op until a local
  costmap on the same node sets `SeaSurfaceLayer.published_topic` to the
  matching topic.
- Affects all echoboats inheriting this base (BizzyBoat 240 + IzzyBoat 160
  + sim).

## Dependencies

- [rolker/unh_marine_perception#20](https://github.com/rolker/unh_marine_perception/pull/20)
  — introduces the `SeaSurfaceRelayLayer` plugin class. Must merge + workspace
  rebuild before this PR's config takes effect.
- Per-platform overlay PR (e.g. BizzyBoat in `unh_echoboats_project11`) wires
  the producer side via `SeaSurfaceLayer.published_topic` — separate PR.

## Test plan

- [ ] yaml parses (`python3 -c "import yaml; yaml.safe_load(...)"` — done locally).
- [ ] Workspace builds with unh_marine_perception#20 + this PR (pending #20 merge).
- [ ] `ros2 launch <bringup>` confirms costmap_2d loads the relay plugin without
      pluginlib resolution errors.
- [ ] Empty-relay smoke: with no producer publishing, the relay logs
      "no message received yet" and stamps nothing — global costmap unchanged
      vs. pre-PR baseline.
- [ ] End-to-end with the BizzyBoat overlay PR + a 2026-05-26 bag replay: lethal
      cells from the local costmap also appear in the global costmap; Smac
      global plan routes around the same buoys that local sees.

Closes #34. Part of the rolker/unh_marine_perception#19 finalization.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
