### PR TITLE
Re-enable velocity_smoother in the cmd_vel chain (disabled in #27) — restore survey accel/yaw limits

### DIFF
--- a/.agent/work-plans/issue-36/plan.md
+++ b/.agent/work-plans/issue-36/plan.md
@@ -1,0 +1,126 @@
+# Plan: Re-enable velocity_smoother in the cmd_vel chain (disabled in #27)
+
+## Issue
+
+https://github.com/rolker/seafloor_echoboat_project11/issues/36
+
+## Context
+
+During the Collision Monitor rework (#170 / #27) the Nav2 `velocity_smoother`
+was pulled out of the active cmd_vel path. Today the chain is:
+
+```
+controller_server / behavior_server ──cmd_vel_nav──▶ collision_monitor ──▶ piloting_mode/autonomous/cmd_vel ──▶ helm
+```
+
+with **no acceleration or yaw smoothing**. The only active yaw governor is the
+helm's `max_yaw_speed: 1.0` rad/s capability backstop, so cmd_vel steps reach the
+thrusters unfiltered. Deployment #197 (2026-05-29) showed the failure mode: a
+near-stop hard pivot + accel snapped yaw to the 1.0 cap as a step and induced
+±30° hull roll.
+
+The smoother caps already exist in the per-model overlays and just aren't running:
+- `nav2_params.240.yaml`: yaw cap `0.45` rad/s, yaw accel `0.2` rad/s² (BizzyBoat)
+- `nav2_params.160.yaml`: yaw cap `1.5` rad/s, yaw accel `1.2` rad/s² (IzzyBoat, skid-steer)
+
+**Why it was removed (#27):** the *old* wiring had the smoother publish its output
+(`cmd_vel_smoothed`) **directly to the helm topic** `piloting_mode/autonomous/cmd_vel`.
+Once #170 added the Collision Monitor (which also publishes there via
+`cmd_vel_out_topic`), that put **two publishers on the helm topic**. The fix here
+inserts the smoother *upstream* of the monitor so the monitor stays the sole helm
+publisher.
+
+## Approach
+
+Target chain (single helm publisher = the monitor; reflex stop still gates):
+
+```
+controller / behaviors ──cmd_vel_nav──▶ velocity_smoother ──cmd_vel_smoothed──▶ collision_monitor ──▶ piloting_mode/autonomous/cmd_vel ──▶ helm
+```
+
+1. **Re-add the `velocity_smoother` LifecycleNode** to `load_nodes` (non-composition
+   path) in `navigation_launch.py`, package `nav2_velocity_smoother`, executable
+   `velocity_smoother`. Remap **input only**: `('cmd_vel', 'cmd_vel_nav')` so it
+   subscribes to the controller/behaviors output. Leave the output at its Nav2
+   default `cmd_vel_smoothed` — **do NOT remap output to the helm topic** (that was
+   the #27 double-publish bug). Place it between `behavior_server` and
+   `collision_monitor` so the read order matches the data flow.
+2. **Mirror the node into the composition path** (`load_composable_nodes`) as a
+   `ComposableNode` with the same input remap, so a future `use_composition=True`
+   can't silently drop the smoother (the #27 progress explicitly hardened this
+   parity — keep it).
+3. **Re-add `'velocity_smoother'`** to the shared `lifecycle_nodes` list (replacing
+   the `# velocity_smoother removed ...` comment at line 49).
+4. **Point the monitor at the smoother** in `nav2_params.base.yaml`:
+   `collision_monitor.cmd_vel_in_topic: cmd_vel_nav → cmd_vel_smoothed` (and update
+   the inline `# (#170)` comment to describe the smoother hop). `cmd_vel_out_topic`
+   stays `piloting_mode/autonomous/cmd_vel`.
+5. **Update the explanatory comments** in `navigation_launch.py` (the
+   "intentionally removed / deliberately disconnected" blocks at lines ~49, ~229–236,
+   ~275–282, ~340–342) to describe the re-enabled, smoother-upstream-of-monitor
+   wiring and cite #36. Stale "deliberately disconnected" comments would actively
+   mislead the next reader.
+6. **Update the wiring test** `test_param_compose.py::test_base_has_no_sensor_rig_or_reflex`:
+   the `cm['cmd_vel_in_topic'] == 'cmd_vel_nav'` assertion (line 189) becomes
+   `'cmd_vel_smoothed'`.
+7. **Add a regression test** that locks the re-enabled wiring so it can't silently
+   regress to the #27 double-publisher: assert (a) `velocity_smoother` is in
+   `lifecycle_nodes`, (b) the smoother's output is **not** remapped to the helm topic,
+   and (c) `collision_monitor.cmd_vel_in_topic == 'cmd_vel_smoothed'` chains to the
+   smoother's output. Implement by AST-parsing `navigation_launch.py` (the existing
+   test already imports from `launch/`), matching the style of `test_param_compose.py`.
+8. **Retest the Collision Monitor interaction in sim** — the reflex stop must still
+   gate correctly with the smoother upstream (smoothed cmd_vel → monitor → helm).
+   Then on-water at Lake Massabesic survey speeds before relying on it.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `echoboat_project11/launch/navigation_launch.py` | Re-add `velocity_smoother` node (non-composition + composition), input remap `cmd_vel→cmd_vel_nav`, re-add to `lifecycle_nodes`, refresh comments |
+| `echoboat_project11/config/nav2_params.base.yaml` | `collision_monitor.cmd_vel_in_topic`: `cmd_vel_nav → cmd_vel_smoothed` + comment |
+| `echoboat_project11/test/test_param_compose.py` | Update `cmd_vel_in_topic` assertion to `cmd_vel_smoothed` |
+| `echoboat_project11/test/test_launch_wiring.py` (new) | Regression test locking smoother-in-lifecycle + no helm double-publish + monitor input chains to smoother |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Quality Standard — fix completely, add the test | Adds a regression test (step 7) that pins the exact failure mode (#27 double-publish), not just a config flip. Comments refreshed so the next reader isn't misled. |
+| Robustness for open-water autonomy | The smoother is inserted **upstream** of the reflex Collision Monitor, so the binary safety floor still gates the final command — smoothing cannot bypass the reflex stop. Verified in sim before on-water (step 8). |
+| Safety lifecycle transition | `velocity_smoother` returns to `lifecycle_nodes` so the lifecycle manager configures/activates it; if it fails to activate, the manager surfaces it rather than silently passing raw cmd_vel. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0008 Follow ROS 2 official conventions | Yes | Uses the stock Nav2 `nav2_velocity_smoother` component and its default `cmd_vel_smoothed` output topic; no custom topic gymnastics. |
+| ADR-0002 Worktree isolation | Yes | Work done in `feature/issue-36` worktree; this plan is the first commit on the branch. |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `lifecycle_nodes` + launch node block (shared, not per-model) | Both 160 (Izzy) and 240 (Bizzy) get the smoother re-enabled — Izzy's caps (yaw 1.5, accel 1.2) are already tuned, so this is consistent, but Izzy is in testing | Yes — flagged as Open Question |
+| `collision_monitor.cmd_vel_in_topic` in `base.yaml` | `test_param_compose.py` assertion | Yes (step 6) |
+| Re-enabled smoother sits upstream of the reflex monitor | The per-boat reflex polygons/observation_sources (supplied via the instance overlay, which lives in the deploying repo, not here) still gate the smoothed output — verify in the sim retest | Yes (step 8) |
+| Smoother is a **flat per-axis limiter** (no speed-scheduling) | A single yaw cap applies at all speeds; "tight at low speed, gentle at speed" would need controller-side logic | No — out of scope, noted as separate concern in the issue |
+
+## Open Questions
+
+- **Yaw cap value (240):** keep the existing `0.45` rad/s survey cap (≈3.4 m turn
+  radius at 1.52 m/s cruise, vs ≈1.5 m at the 1.0 helm clamp)? The issue recommends
+  keeping `0.45` and leaving `max_yaw_speed: 1.0` as the helm capability backstop.
+  Confirm before tuning, since it directly sets survey turn geometry.
+- **Enable for IzzyBoat (160) too?** The shared launch/lifecycle list re-enables the
+  smoother for both hulls. Izzy's caps are already tuned and distinct, but it's in
+  testing — OK to enable now, or gate to 240 only (would require per-model launch
+  logic)?
+- **On-water validation window:** the sim retest is in-scope here; the on-water
+  Collision-Monitor-interaction check needs a deployment slot before the June 4 dev
+  freeze. Schedule under an existing deployment issue or a dedicated test run?
+
+## Estimated Scope
+
+Single PR (launch + base param + tests). The on-water validation (step 8) is a
+follow-up field check tracked against a deployment, not a code change in this PR.

--- a/.agent/work-plans/issue-36/plan.md
+++ b/.agent/work-plans/issue-36/plan.md
@@ -129,13 +129,13 @@ controller / behaviors ──cmd_vel_nav──▶ velocity_smoother ──cmd_ve
 - ~~**Yaw cap value (240)?**~~ **Resolved (Roland, 2026-06-02):** keep steady-state
   yaw rate at full `1.0` rad/s; govern the snap with the yaw **accel** cap, starting
   at `0.5` rad/s² (~2 s ramp), sim/on-water tunable. See Context.
-- **Enable for IzzyBoat (160) too?** The shared launch/lifecycle list re-enables the
-  smoother for both hulls. Izzy's caps are already tuned and distinct, but it's in
-  testing — OK to enable now, or gate to 240 only (would require per-model launch
-  logic)?
-- **On-water validation window:** the sim retest is in-scope here; the on-water
-  Collision-Monitor-interaction check needs a deployment slot before the June 4 dev
-  freeze. Schedule under an existing deployment issue or a dedicated test run?
+- ~~**Enable for IzzyBoat (160) too?**~~ **Resolved (Roland, 2026-06-02): both.**
+  The shared launch/lifecycle list re-enables the smoother for both hulls — no
+  per-model gating, which is also the simpler path. Izzy's existing distinct caps
+  (yaw 1.5, accel 1.2) stand.
+- ~~**On-water validation window?**~~ **Resolved (Roland, 2026-06-02):** bundle the
+  on-water Collision-Monitor-interaction check into the **next existing deployment
+  issue's** validation, not a standalone test run. (Sim retest remains in-scope here.)
 
 ## Estimated Scope
 

--- a/.agent/work-plans/issue-36/plan.md
+++ b/.agent/work-plans/issue-36/plan.md
@@ -19,9 +19,21 @@ thrusters unfiltered. Deployment #197 (2026-05-29) showed the failure mode: a
 near-stop hard pivot + accel snapped yaw to the 1.0 cap as a step and induced
 ±30° hull roll.
 
-The smoother caps already exist in the per-model overlays and just aren't running:
-- `nav2_params.240.yaml`: yaw cap `0.45` rad/s, yaw accel `0.2` rad/s² (BizzyBoat)
-- `nav2_params.160.yaml`: yaw cap `1.5` rad/s, yaw accel `1.2` rad/s² (IzzyBoat, skid-steer)
+The smoother caps exist in the per-model overlays and just aren't running. The 240
+caps are **re-tuned** by this work (decision below):
+- `nav2_params.240.yaml`: yaw **speed** cap `0.45 → 1.0` rad/s (full helm capability),
+  yaw **accel** cap `0.2 → 0.5` rad/s² (BizzyBoat) — the accel limit, not the speed
+  cap, becomes the governor against the #197 snap-roll
+- `nav2_params.160.yaml`: yaw cap `1.5` rad/s, yaw accel `1.2` rad/s² (IzzyBoat,
+  skid-steer) — left as-is
+
+**Cap-tuning decision (resolves Open Question 1):** #197 was a yaw *step* (snapped to
+1.0 rad/s and reversed) that shock-loaded the hull into ±30° roll — not a "turned too
+fast" event. So we keep the steady-state yaw rate at the full `1.0` rad/s capability
+(no turn-radius penalty) and govern the transient with the yaw **acceleration** cap.
+`0.5` rad/s² ramps 0→1.0 rad/s over ~2.0 s (vs the ~0.2 s control-tick step that rolled
+her), symmetric `max_decel = -0.5` since the event involved a reversal. Starting value;
+sim/on-water tunable (0.2 = 5 s sluggish … 1.0 = 1 s aggressive).
 
 **Why it was removed (#27):** the *old* wiring had the smoother publish its output
 (`cmd_vel_smoothed`) **directly to the helm topic** `piloting_mode/autonomous/cmd_vel`.
@@ -69,7 +81,12 @@ controller / behaviors ──cmd_vel_nav──▶ velocity_smoother ──cmd_ve
    and (c) `collision_monitor.cmd_vel_in_topic == 'cmd_vel_smoothed'` chains to the
    smoother's output. Implement by AST-parsing `navigation_launch.py` (the existing
    test already imports from `launch/`), matching the style of `test_param_compose.py`.
-8. **Retest the Collision Monitor interaction in sim** — the reflex stop must still
+8. **Re-tune the 240 yaw caps** in `nav2_params.240.yaml`: `max_velocity` yaw
+   `0.45 → 1.0`, `min_velocity` yaw `-0.45 → -1.0`, `max_accel` yaw `0.2 → 0.5`,
+   `max_decel` yaw `-0.2 → -0.5` (x/y components unchanged). Update
+   `test_param_compose.py::test_merged_240_hull_values` (line 85), which asserts
+   `max_velocity == [2.75, 0.0, 0.45]`, to `[2.75, 0.0, 1.0]`.
+9. **Retest the Collision Monitor interaction in sim** — the reflex stop must still
    gate correctly with the smoother upstream (smoothed cmd_vel → monitor → helm).
    Then on-water at Lake Massabesic survey speeds before relying on it.
 
@@ -79,7 +96,8 @@ controller / behaviors ──cmd_vel_nav──▶ velocity_smoother ──cmd_ve
 |------|--------|
 | `echoboat_project11/launch/navigation_launch.py` | Re-add `velocity_smoother` node (non-composition + composition), input remap `cmd_vel→cmd_vel_nav`, re-add to `lifecycle_nodes`, refresh comments |
 | `echoboat_project11/config/nav2_params.base.yaml` | `collision_monitor.cmd_vel_in_topic`: `cmd_vel_nav → cmd_vel_smoothed` + comment |
-| `echoboat_project11/test/test_param_compose.py` | Update `cmd_vel_in_topic` assertion to `cmd_vel_smoothed` |
+| `echoboat_project11/config/nav2_params.240.yaml` | yaw caps: `max_velocity`/`min_velocity` `±0.45 → ±1.0`, `max_accel`/`max_decel` yaw `±0.2 → ±0.5` |
+| `echoboat_project11/test/test_param_compose.py` | Update `cmd_vel_in_topic` assertion → `cmd_vel_smoothed`; update `test_merged_240_hull_values` `max_velocity` → `[2.75, 0.0, 1.0]` |
 | `echoboat_project11/test/test_launch_wiring.py` (new) | Regression test locking smoother-in-lifecycle + no helm double-publish + monitor input chains to smoother |
 
 ## Principles Self-Check
@@ -108,10 +126,9 @@ controller / behaviors ──cmd_vel_nav──▶ velocity_smoother ──cmd_ve
 
 ## Open Questions
 
-- **Yaw cap value (240):** keep the existing `0.45` rad/s survey cap (≈3.4 m turn
-  radius at 1.52 m/s cruise, vs ≈1.5 m at the 1.0 helm clamp)? The issue recommends
-  keeping `0.45` and leaving `max_yaw_speed: 1.0` as the helm capability backstop.
-  Confirm before tuning, since it directly sets survey turn geometry.
+- ~~**Yaw cap value (240)?**~~ **Resolved (Roland, 2026-06-02):** keep steady-state
+  yaw rate at full `1.0` rad/s; govern the snap with the yaw **accel** cap, starting
+  at `0.5` rad/s² (~2 s ramp), sim/on-water tunable. See Context.
 - **Enable for IzzyBoat (160) too?** The shared launch/lifecycle list re-enables the
   smoother for both hulls. Izzy's caps are already tuned and distinct, but it's in
   testing — OK to enable now, or gate to 240 only (would require per-model launch

--- a/.agent/work-plans/issue-36/progress.md
+++ b/.agent/work-plans/issue-36/progress.md
@@ -17,3 +17,24 @@ issue: 36
 - [ ] Yaw cap value (240): keep existing 0.45 rad/s survey cap (~3.4 m turn radius at cruise) vs the 1.0 helm clamp?
 - [ ] Enable the smoother for IzzyBoat (160) too — shared launch/lifecycle re-enables both hulls (160 is in testing)?
 - [ ] On-water Collision-Monitor-interaction validation: which deployment slot before the June 4 dev freeze?
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-02 10:46 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: approved
+**Branch**: feature/issue-36 at `afa93bb`
+**Mode**: pre-push
+**Depth**: Deep (reason: safety-critical cmd_vel routing + Collision Monitor gating / lifecycle)
+**Must-fix**: 0 | **Suggestions**: 4
+
+### Findings
+- [x] (suggestion) enable_stamped_cmd_vel consistency untested — Twist/TwistStamped mismatch would silently break the chain — FIXED, added `test_stamped_cmd_vel_consistent_across_chain` — `test/test_launch_wiring.py`
+- [ ] (suggestion, behavioral) `scale_velocities: true` couples axes: a large yaw-accel-limited turn scales surge DOWN too (slows on straightaway) — decide scale_velocities true vs false at on-water tune — `config/nav2_params.base.yaml:277`
+- [ ] (suggestion, behavioral) smoother adds `velocity_timeout: 1.0`s hold + decel ramp on `cmd_vel_smoothed` after cmd_vel_nav goes silent — autonomy-stop now decays over ~1 s; confirm prompt stop on-water — `config/nav2_params.base.yaml:282`
+- [ ] (note, pre-existing/out-of-scope) composition path lists `manda_coverage` in lifecycle_nodes but never loads the component (predates #36; composition unused in field, use_composition=False) — `launch/navigation_launch.py`
+- [x] (suggestion) wiring test guards literal remaps only (misses SetRemap/shared-var) and len==2 exact — accepted scope limit (launch uses literal remaps throughout)
+
+### Adversarial verification
+- Claude adversarial verified topic names against installed nav2 binaries: velocity_smoother subscribes `cmd_vel` / publishes `cmd_vel_smoothed` (input remap correct), all 4 hops TwistStamped (types match), monitor sole helm publisher in both paths, 240 caps pass on_configure validation, OPEN_LOOP = no odom activation hazard.
+- Copilot adversarial (cross-model) concurred; no double-publisher, no type mismatch.

--- a/.agent/work-plans/issue-36/progress.md
+++ b/.agent/work-plans/issue-36/progress.md
@@ -1,0 +1,19 @@
+---
+issue: 36
+---
+
+# Issue #36 — Re-enable velocity_smoother in the cmd_vel chain (disabled in #27)
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-02 09:40 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Plan**: `.agent/work-plans/issue-36/plan.md` at `49cc506`
+**PR**: https://github.com/rolker/seafloor_echoboat_project11/pull/37 (`[PLAN]` prefix)
+**Phases**: single
+
+### Open questions
+- [ ] Yaw cap value (240): keep existing 0.45 rad/s survey cap (~3.4 m turn radius at cruise) vs the 1.0 helm clamp?
+- [ ] Enable the smoother for IzzyBoat (160) too — shared launch/lifecycle re-enables both hulls (160 is in testing)?
+- [ ] On-water Collision-Monitor-interaction validation: which deployment slot before the June 4 dev freeze?

--- a/echoboat_project11/CMakeLists.txt
+++ b/echoboat_project11/CMakeLists.txt
@@ -9,6 +9,7 @@ install(DIRECTORY config DESTINATION share/${PROJECT_NAME})
 if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
   ament_add_pytest_test(test_param_compose test/test_param_compose.py)
+  ament_add_pytest_test(test_launch_wiring test/test_launch_wiring.py)
 endif()
 
 ament_package()

--- a/echoboat_project11/config/nav2_params.240.yaml
+++ b/echoboat_project11/config/nav2_params.240.yaml
@@ -36,7 +36,13 @@ behavior_server:
 
 velocity_smoother:
   ros__parameters:
-    max_velocity: [2.75, 0.0, 0.45]
-    min_velocity: [-0.5, 0.0, -0.45]
-    max_accel: [0.8, 0.0, 0.2]
-    max_decel: [-0.45, 0.0, -0.2]
+    # Yaw is governed by the ACCELERATION cap, not the speed cap (#36). The #197
+    # snap-roll was a yaw *step* (snapped to 1.0 rad/s and reversed → ±30° hull
+    # roll), not over-speed. So the steady-state yaw rate keeps the full 1.0 rad/s
+    # vectored-thrust capability (matching the helm max_yaw_speed backstop) while
+    # the yaw accel/decel cap (±0.5 rad/s², ~2 s ramp 0→1.0) spreads the moment
+    # buildup that drove the roll. Starting value — sim/on-water tunable.
+    max_velocity: [2.75, 0.0, 1.0]
+    min_velocity: [-0.5, 0.0, -1.0]
+    max_accel: [0.8, 0.0, 0.5]
+    max_decel: [-0.45, 0.0, -0.5]

--- a/echoboat_project11/config/nav2_params.base.yaml
+++ b/echoboat_project11/config/nav2_params.base.yaml
@@ -286,7 +286,7 @@ collision_monitor:
   ros__parameters:
     base_frame_id: <tf_prefix>/base_link
     odom_frame_id: <tf_prefix>/odom
-    cmd_vel_in_topic: "cmd_vel_nav"          # controller/behaviors publish here; monitor gates → out (#170)
+    cmd_vel_in_topic: "cmd_vel_smoothed"     # velocity_smoother output (cmd_vel_nav→smoother→here); monitor gates → out (#36)
     cmd_vel_out_topic: "piloting_mode/autonomous/cmd_vel"
     enable_stamped_cmd_vel: true
     state_topic: "collision_monitor_state"

--- a/echoboat_project11/launch/navigation_launch.py
+++ b/echoboat_project11/launch/navigation_launch.py
@@ -46,7 +46,9 @@ def generate_launch_description():
         'smoother_server',
         'planner_server',
         'behavior_server',
-        # velocity_smoother removed from the active path (#170) — see node block below
+        # velocity_smoother re-enabled (#36), now upstream of the Collision Monitor
+        # (cmd_vel_nav -> smoother -> cmd_vel_smoothed -> monitor) — see node block below
+        'velocity_smoother',
         'collision_monitor',
         #'bt_navigator',
         'manda_coverage',
@@ -226,14 +228,31 @@ def generate_launch_description():
                 namespace="",
                 emulate_tty=True
             ),
-            # velocity_smoother intentionally removed from the active path (#170).
-            # The cmd_vel filter chain is deliberately disconnected on these boats,
-            # so the controller feeds the Collision Monitor directly via cmd_vel_nav.
-            # Leaving the smoother here would put a second publisher on
-            # piloting_mode/autonomous/cmd_vel, competing with the monitor. To
-            # re-enable smoothing later, restore this node with its output remapped
-            # to cmd_vel_smoothed and set collision_monitor cmd_vel_in_topic back to
-            # cmd_vel_smoothed (and re-add 'velocity_smoother' to lifecycle_nodes).
+            # velocity_smoother re-enabled (#36), inserted UPSTREAM of the Collision
+            # Monitor: it subscribes to the controller/behaviors output (cmd_vel_nav)
+            # and publishes the Nav2-default cmd_vel_smoothed, which the monitor then
+            # gates (collision_monitor cmd_vel_in_topic: cmd_vel_smoothed in
+            # nav2_params.base.yaml) before emitting piloting_mode/autonomous/cmd_vel.
+            # Output is deliberately left at cmd_vel_smoothed and NOT remapped to the
+            # helm topic — remapping it there was the #27 double-publisher bug (two
+            # publishers on piloting_mode/autonomous/cmd_vel: the smoother and the
+            # monitor). The monitor stays the sole helm publisher.
+            LifecycleNode(
+                package='nav2_velocity_smoother',
+                executable='velocity_smoother',
+                name='velocity_smoother',
+                output='screen',
+                respawn=use_respawn,
+                respawn_delay=2.0,
+                parameters=[configured_params],
+                arguments=['--ros-args', '--log-level', log_level],
+                # Input only: subscribe to the controller/behaviors output. Output
+                # stays at the default cmd_vel_smoothed (do NOT route to the helm
+                # topic — see comment above / #27).
+                remappings=remappings + [('cmd_vel', 'cmd_vel_nav')],
+                namespace="",
+                emulate_tty=True
+            ),
             LifecycleNode(
                 package='nav2_collision_monitor',
                 executable='collision_monitor',
@@ -272,14 +291,15 @@ def generate_launch_description():
         ],
     )
 
-    # NOTE (#170): this composition path mirrors the non-composition routing —
-    # controller/behaviors publish cmd_vel_nav and the Collision Monitor gates it
-    # (cmd_vel_in_topic: cmd_vel_nav -> cmd_vel_out_topic:
-    # piloting_mode/autonomous/cmd_vel, both from nav2_params.base.yaml). velocity_smoother
-    # is omitted here too (the cmd_vel filter chain is deliberately disconnected on
-    # these boats; it is also absent from lifecycle_nodes above). This path stays
-    # UNUSED in the field (use_composition=False), but is kept consistent so enabling
-    # composition cannot silently reintroduce the gating bypass.
+    # NOTE (#36): this composition path mirrors the non-composition routing —
+    # controller/behaviors publish cmd_vel_nav -> velocity_smoother (input remapped
+    # to cmd_vel_nav, output at the default cmd_vel_smoothed) -> Collision Monitor
+    # (cmd_vel_in_topic: cmd_vel_smoothed -> cmd_vel_out_topic:
+    # piloting_mode/autonomous/cmd_vel, both from nav2_params.base.yaml). The smoother
+    # is included here too and is present in lifecycle_nodes above. Its output is NOT
+    # remapped to the helm topic (that was the #27 double-publisher bug). This path
+    # stays UNUSED in the field (use_composition=False), but is kept consistent so
+    # enabling composition cannot silently drop the smoother or reintroduce the bypass.
     load_composable_nodes = GroupAction(
         condition=IfCondition(use_composition),
         actions=[
@@ -337,9 +357,17 @@ def generate_launch_description():
                         parameters=[configured_params],
                         remappings=remappings,
                     ),
-                    # velocity_smoother intentionally omitted (see NOTE above) —
-                    # mirrors its removal from the non-composition path so the
-                    # Collision Monitor is the sole publisher on the helm topic.
+                    # velocity_smoother re-enabled (#36), mirroring the non-composition
+                    # path: input remapped to cmd_vel_nav, output left at the default
+                    # cmd_vel_smoothed (NOT the helm topic — #27). The Collision Monitor
+                    # remains the sole publisher on piloting_mode/autonomous/cmd_vel.
+                    ComposableNode(
+                        package='nav2_velocity_smoother',
+                        plugin='nav2_velocity_smoother::VelocitySmoother',
+                        name='velocity_smoother',
+                        parameters=[configured_params],
+                        remappings=remappings + [('cmd_vel', 'cmd_vel_nav')],
+                    ),
                     ComposableNode(
                         package='nav2_collision_monitor',
                         plugin='nav2_collision_monitor::CollisionMonitor',

--- a/echoboat_project11/test/test_launch_wiring.py
+++ b/echoboat_project11/test/test_launch_wiring.py
@@ -1,0 +1,144 @@
+"""Tests for the cmd_vel chain wiring in navigation_launch.py (issue #36).
+
+Locks the re-enabled velocity_smoother routing so it can't silently regress to
+the #27 double-publisher bug. The intended chain is:
+
+    controller / behaviors --cmd_vel_nav--> velocity_smoother
+        --cmd_vel_smoothed--> collision_monitor --> piloting_mode/autonomous/cmd_vel
+
+The Collision Monitor must stay the SOLE publisher on the helm topic
+(piloting_mode/autonomous/cmd_vel). The #27 regression was the smoother
+publishing its output straight to the helm topic, competing with the monitor.
+
+These parse the launch file's AST (no ROS runtime needed) plus the shared base
+params, matching the static style of test_param_compose.py.
+"""
+
+import ast
+import os
+
+import yaml
+
+_PKG = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_LAUNCH_FILE = os.path.join(_PKG, 'launch', 'navigation_launch.py')
+_CONFIG = os.path.join(_PKG, 'config')
+
+_HELM_TOPIC = 'piloting_mode/autonomous/cmd_vel'
+_NODE_CALLS = ('LifecycleNode', 'ComposableNode', 'Node')
+
+
+def _launch_tree():
+    with open(_LAUNCH_FILE) as f:
+        return ast.parse(f.read())
+
+
+def _str(node):
+    """Return the string value of a Constant node, else None."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _lifecycle_nodes(tree):
+    """The string elements of the `lifecycle_nodes = [...]` list literal."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == 'lifecycle_nodes' for t in node.targets
+        ):
+            return [_str(el) for el in node.value.elts if _str(el) is not None]
+    raise AssertionError('lifecycle_nodes assignment not found in launch file')
+
+
+def _remap_tuples(expr):
+    """All 2-string (from, to) remap pairs in any list literal within expr.
+
+    Handles both `remappings + [('a', 'b')]` (BinOp) and a bare list literal.
+    """
+    pairs = []
+    for sub in ast.walk(expr):
+        if isinstance(sub, ast.List):
+            for el in sub.elts:
+                if isinstance(el, ast.Tuple) and len(el.elts) == 2:
+                    a, b = _str(el.elts[0]), _str(el.elts[1])
+                    if a is not None and b is not None:
+                        pairs.append((a, b))
+    return pairs
+
+
+def _node_calls(tree):
+    """List of (name, remap_pairs) for every node-constructing call in the launch."""
+    out = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in _NODE_CALLS
+        ):
+            name, remaps = None, []
+            for kw in node.keywords:
+                if kw.arg == 'name':
+                    name = _str(kw.value)
+                elif kw.arg == 'remappings':
+                    remaps = _remap_tuples(kw.value)
+            out.append((name, remaps))
+    return out
+
+
+# --- velocity_smoother is back in the active lifecycle ---
+
+def test_velocity_smoother_in_lifecycle_nodes():
+    assert 'velocity_smoother' in _lifecycle_nodes(_launch_tree())
+
+
+def test_velocity_smoother_node_present_both_paths():
+    """One non-composition LifecycleNode + one composition ComposableNode."""
+    smoothers = [c for c in _node_calls(_launch_tree()) if c[0] == 'velocity_smoother']
+    assert len(smoothers) == 2, (
+        f'expected velocity_smoother in both launch paths, found {len(smoothers)}'
+    )
+
+
+def test_velocity_smoother_input_remapped_to_cmd_vel_nav():
+    """Subscribes to the controller/behaviors output, in every path it appears."""
+    smoothers = [c for c in _node_calls(_launch_tree()) if c[0] == 'velocity_smoother']
+    assert smoothers, 'no velocity_smoother node found'
+    for _, remaps in smoothers:
+        assert ('cmd_vel', 'cmd_vel_nav') in remaps
+
+
+def test_velocity_smoother_output_not_redirected():
+    """Output stays at the Nav2 default cmd_vel_smoothed — not remapped anywhere
+    (and certainly not to the helm topic). Redirecting cmd_vel_smoothed was the
+    #27 double-publish bug."""
+    for name, remaps in _node_calls(_launch_tree()):
+        if name == 'velocity_smoother':
+            froms = [src for src, _ in remaps]
+            assert 'cmd_vel_smoothed' not in froms, (
+                'velocity_smoother output is remapped — leave it at the default'
+            )
+
+
+# --- #27 guard: the monitor is the SOLE helm-topic publisher ---
+
+def test_no_launch_node_remaps_to_helm_topic():
+    """The helm topic must only be produced by the Collision Monitor's
+    cmd_vel_out_topic param — never by a launch remap. A remap target equal to
+    the helm topic means a second publisher (the #27 regression)."""
+    for name, remaps in _node_calls(_launch_tree()):
+        targets = [dst for _, dst in remaps]
+        assert _HELM_TOPIC not in targets, (
+            f'{name} remaps an output to the helm topic ({_HELM_TOPIC}) — '
+            'reintroduces the #27 double-publisher'
+        )
+
+
+# --- chain consistency: monitor input == smoother output ---
+
+def test_monitor_input_chains_to_smoother_output():
+    with open(os.path.join(_CONFIG, 'nav2_params.base.yaml')) as f:
+        base = yaml.safe_load(f)
+    cm = base['collision_monitor']['ros__parameters']
+    # smoother publishes the Nav2 default cmd_vel_smoothed; the monitor reads it
+    assert cm['cmd_vel_in_topic'] == 'cmd_vel_smoothed'
+    # and the monitor alone emits the helm topic
+    assert cm['cmd_vel_out_topic'] == _HELM_TOPIC

--- a/echoboat_project11/test/test_launch_wiring.py
+++ b/echoboat_project11/test/test_launch_wiring.py
@@ -142,3 +142,20 @@ def test_monitor_input_chains_to_smoother_output():
     assert cm['cmd_vel_in_topic'] == 'cmd_vel_smoothed'
     # and the monitor alone emits the helm topic
     assert cm['cmd_vel_out_topic'] == _HELM_TOPIC
+
+
+def test_stamped_cmd_vel_consistent_across_chain():
+    """Every hop must agree on TwistStamped vs Twist (enable_stamped_cmd_vel).
+    Nav2's TwistSubscriber/TwistPublisher pick the message type off this per-node
+    param; a single node disagreeing silently breaks the topic connection (wrong
+    type = no delivery), with no launch-time or runtime error. A new node added to
+    the chain with the param defaulted/omitted is the realistic regression."""
+    with open(os.path.join(_CONFIG, 'nav2_params.base.yaml')) as f:
+        base = yaml.safe_load(f)
+    chain = ['controller_server', 'behavior_server', 'velocity_smoother',
+             'collision_monitor']
+    for node in chain:
+        params = base[node]['ros__parameters']
+        assert params.get('enable_stamped_cmd_vel') is True, (
+            f'{node} must set enable_stamped_cmd_vel: true to match the cmd_vel chain'
+        )

--- a/echoboat_project11/test/test_param_compose.py
+++ b/echoboat_project11/test/test_param_compose.py
@@ -82,7 +82,12 @@ def test_merged_240_hull_values():
     assert _gc(p)['robot_radius'] == 1.5
     assert 'footprint' in _lc(p) and 'footprint' in _gc(p)
     assert p['planner_server']['ros__parameters']['GridBased']['minimum_turning_radius'] == 1.5
-    assert p['velocity_smoother']['ros__parameters']['max_velocity'] == [2.75, 0.0, 0.45]
+    # Yaw speed cap is the full 1.0 rad/s capability; the yaw accel cap is the
+    # governor (#36). Guards against a revert to the old 0.45 survey speed clamp.
+    vs = p['velocity_smoother']['ros__parameters']
+    assert vs['max_velocity'] == [2.75, 0.0, 1.0]
+    assert vs['max_accel'] == [0.8, 0.0, 0.5]
+    assert vs['max_decel'] == [-0.45, 0.0, -0.5]
     bs = p['behavior_server']['ros__parameters']
     assert bs['max_rotational_vel'] == 1.0
     assert bs['hover']['maximum_speed'] == 1.0
@@ -185,7 +190,10 @@ def test_base_has_no_sensor_rig_or_reflex():
     assert lc['plugins'] == ['chart_layer', 'inflation_layer']
     assert not [k for k in lc if 'sea_surface' in k]
     cm = base['collision_monitor']['ros__parameters']
-    # gating wiring stays; reflex zones/sources move to the instance overlay
-    assert cm['cmd_vel_in_topic'] == 'cmd_vel_nav'
+    # gating wiring stays; reflex zones/sources move to the instance overlay.
+    # The monitor's input is the velocity_smoother output (#36): the smoother sits
+    # upstream (cmd_vel_nav -> smoother -> cmd_vel_smoothed -> monitor), so the
+    # reflex still gates the final command.
+    assert cm['cmd_vel_in_topic'] == 'cmd_vel_smoothed'
     assert cm['polygons'] == []
     assert cm['observation_sources'] == []


### PR DESCRIPTION
Closes #36

# Plan: Re-enable velocity_smoother in the cmd_vel chain (disabled in #27)

## Issue

https://github.com/rolker/seafloor_echoboat_project11/issues/36

## Context

During the Collision Monitor rework (#170 / #27) the Nav2 `velocity_smoother`
was pulled out of the active cmd_vel path. Today the chain is:

```
controller_server / behavior_server ──cmd_vel_nav──▶ collision_monitor ──▶ piloting_mode/autonomous/cmd_vel ──▶ helm
```

with **no acceleration or yaw smoothing**. The only active yaw governor is the
helm's `max_yaw_speed: 1.0` rad/s capability backstop, so cmd_vel steps reach the
thrusters unfiltered. Deployment #197 (2026-05-29) showed the failure mode: a
near-stop hard pivot + accel snapped yaw to the 1.0 cap as a step and induced
±30° hull roll.

The smoother caps exist in the per-model overlays and just aren't running. The 240
caps are **re-tuned** by this work (decision below):
- `nav2_params.240.yaml`: yaw **speed** cap `0.45 → 1.0` rad/s (full helm capability),
  yaw **accel** cap `0.2 → 0.5` rad/s² (BizzyBoat) — the accel limit, not the speed
  cap, becomes the governor against the #197 snap-roll
- `nav2_params.160.yaml`: yaw cap `1.5` rad/s, yaw accel `1.2` rad/s² (IzzyBoat,
  skid-steer) — left as-is

**Cap-tuning decision (resolves Open Question 1):** #197 was a yaw *step* (snapped to
1.0 rad/s and reversed) that shock-loaded the hull into ±30° roll — not a "turned too
fast" event. So we keep the steady-state yaw rate at the full `1.0` rad/s capability
(no turn-radius penalty) and govern the transient with the yaw **acceleration** cap.
`0.5` rad/s² ramps 0→1.0 rad/s over ~2.0 s (vs the ~0.2 s control-tick step that rolled
her), symmetric `max_decel = -0.5` since the event involved a reversal. Starting value;
sim/on-water tunable (0.2 = 5 s sluggish … 1.0 = 1 s aggressive).

**Why it was removed (#27):** the *old* wiring had the smoother publish its output
(`cmd_vel_smoothed`) **directly to the helm topic** `piloting_mode/autonomous/cmd_vel`.
Once #170 added the Collision Monitor (which also publishes there via
`cmd_vel_out_topic`), that put **two publishers on the helm topic**. The fix here
inserts the smoother *upstream* of the monitor so the monitor stays the sole helm
publisher.

## Approach

Target chain (single helm publisher = the monitor; reflex stop still gates):

```
controller / behaviors ──cmd_vel_nav──▶ velocity_smoother ──cmd_vel_smoothed──▶ collision_monitor ──▶ piloting_mode/autonomous/cmd_vel ──▶ helm
```

1. **Re-add the `velocity_smoother` LifecycleNode** to `load_nodes` (non-composition
   path) in `navigation_launch.py`, package `nav2_velocity_smoother`, executable
   `velocity_smoother`. Remap **input only**: `('cmd_vel', 'cmd_vel_nav')` so it
   subscribes to the controller/behaviors output. Leave the output at its Nav2
   default `cmd_vel_smoothed` — **do NOT remap output to the helm topic** (that was
   the #27 double-publish bug). Place it between `behavior_server` and
   `collision_monitor` so the read order matches the data flow.
2. **Mirror the node into the composition path** (`load_composable_nodes`) as a
   `ComposableNode` with the same input remap, so a future `use_composition=True`
   can't silently drop the smoother (the #27 progress explicitly hardened this
   parity — keep it).
3. **Re-add `'velocity_smoother'`** to the shared `lifecycle_nodes` list (replacing
   the `# velocity_smoother removed ...` comment at line 49).
4. **Point the monitor at the smoother** in `nav2_params.base.yaml`:
   `collision_monitor.cmd_vel_in_topic: cmd_vel_nav → cmd_vel_smoothed` (and update
   the inline `# (#170)` comment to describe the smoother hop). `cmd_vel_out_topic`
   stays `piloting_mode/autonomous/cmd_vel`.
5. **Update the explanatory comments** in `navigation_launch.py` (the
   "intentionally removed / deliberately disconnected" blocks at lines ~49, ~229–236,
   ~275–282, ~340–342) to describe the re-enabled, smoother-upstream-of-monitor
   wiring and cite #36. Stale "deliberately disconnected" comments would actively
   mislead the next reader.
6. **Update the wiring test** `test_param_compose.py::test_base_has_no_sensor_rig_or_reflex`:
   the `cm['cmd_vel_in_topic'] == 'cmd_vel_nav'` assertion (line 189) becomes
   `'cmd_vel_smoothed'`.
7. **Add a regression test** that locks the re-enabled wiring so it can't silently
   regress to the #27 double-publisher: assert (a) `velocity_smoother` is in
   `lifecycle_nodes`, (b) the smoother's output is **not** remapped to the helm topic,
   and (c) `collision_monitor.cmd_vel_in_topic == 'cmd_vel_smoothed'` chains to the
   smoother's output. Implement by AST-parsing `navigation_launch.py` (the existing
   test already imports from `launch/`), matching the style of `test_param_compose.py`.
8. **Re-tune the 240 yaw caps** in `nav2_params.240.yaml`: `max_velocity` yaw
   `0.45 → 1.0`, `min_velocity` yaw `-0.45 → -1.0`, `max_accel` yaw `0.2 → 0.5`,
   `max_decel` yaw `-0.2 → -0.5` (x/y components unchanged). Update
   `test_param_compose.py::test_merged_240_hull_values` (line 85), which asserts
   `max_velocity == [2.75, 0.0, 0.45]`, to `[2.75, 0.0, 1.0]`.
9. **Retest the Collision Monitor interaction in sim** — the reflex stop must still
   gate correctly with the smoother upstream (smoothed cmd_vel → monitor → helm).
   Then on-water at Lake Massabesic survey speeds before relying on it.

## Files to Change

| File | Change |
|------|--------|
| `echoboat_project11/launch/navigation_launch.py` | Re-add `velocity_smoother` node (non-composition + composition), input remap `cmd_vel→cmd_vel_nav`, re-add to `lifecycle_nodes`, refresh comments |
| `echoboat_project11/config/nav2_params.base.yaml` | `collision_monitor.cmd_vel_in_topic`: `cmd_vel_nav → cmd_vel_smoothed` + comment |
| `echoboat_project11/config/nav2_params.240.yaml` | yaw caps: `max_velocity`/`min_velocity` `±0.45 → ±1.0`, `max_accel`/`max_decel` yaw `±0.2 → ±0.5` |
| `echoboat_project11/test/test_param_compose.py` | Update `cmd_vel_in_topic` assertion → `cmd_vel_smoothed`; update `test_merged_240_hull_values` `max_velocity` → `[2.75, 0.0, 1.0]` |
| `echoboat_project11/test/test_launch_wiring.py` (new) | Regression test locking smoother-in-lifecycle + no helm double-publish + monitor input chains to smoother |

## Principles Self-Check

| Principle | Consideration |
|---|---|
| Quality Standard — fix completely, add the test | Adds a regression test (step 7) that pins the exact failure mode (#27 double-publish), not just a config flip. Comments refreshed so the next reader isn't misled. |
| Robustness for open-water autonomy | The smoother is inserted **upstream** of the reflex Collision Monitor, so the binary safety floor still gates the final command — smoothing cannot bypass the reflex stop. Verified in sim before on-water (step 8). |
| Safety lifecycle transition | `velocity_smoother` returns to `lifecycle_nodes` so the lifecycle manager configures/activates it; if it fails to activate, the manager surfaces it rather than silently passing raw cmd_vel. |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| ADR-0008 Follow ROS 2 official conventions | Yes | Uses the stock Nav2 `nav2_velocity_smoother` component and its default `cmd_vel_smoothed` output topic; no custom topic gymnastics. |
| ADR-0002 Worktree isolation | Yes | Work done in `feature/issue-36` worktree; this plan is the first commit on the branch. |

## Consequences

| If we change... | Also update... | Included in plan? |
|---|---|---|
| `lifecycle_nodes` + launch node block (shared, not per-model) | Both 160 (Izzy) and 240 (Bizzy) get the smoother re-enabled — Izzy's caps (yaw 1.5, accel 1.2) are already tuned, so this is consistent, but Izzy is in testing | Yes — flagged as Open Question |
| `collision_monitor.cmd_vel_in_topic` in `base.yaml` | `test_param_compose.py` assertion | Yes (step 6) |
| Re-enabled smoother sits upstream of the reflex monitor | The per-boat reflex polygons/observation_sources (supplied via the instance overlay, which lives in the deploying repo, not here) still gate the smoothed output — verify in the sim retest | Yes (step 8) |
| Smoother is a **flat per-axis limiter** (no speed-scheduling) | A single yaw cap applies at all speeds; "tight at low speed, gentle at speed" would need controller-side logic | No — out of scope, noted as separate concern in the issue |

## Open Questions

- ~~**Yaw cap value (240)?**~~ **Resolved (Roland, 2026-06-02):** keep steady-state
  yaw rate at full `1.0` rad/s; govern the snap with the yaw **accel** cap, starting
  at `0.5` rad/s² (~2 s ramp), sim/on-water tunable. See Context.
- ~~**Enable for IzzyBoat (160) too?**~~ **Resolved (Roland, 2026-06-02): both.**
  The shared launch/lifecycle list re-enables the smoother for both hulls — no
  per-model gating, which is also the simpler path. Izzy's existing distinct caps
  (yaw 1.5, accel 1.2) stand.
- ~~**On-water validation window?**~~ **Resolved (Roland, 2026-06-02):** bundle the
  on-water Collision-Monitor-interaction check into the **next existing deployment
  issue's** validation, not a standalone test run. (Sim retest remains in-scope here.)

## Estimated Scope

Single PR (launch + base param + tests). The on-water validation (step 8) is a
follow-up field check tracked against a deployment, not a code change in this PR.
