### PR TITLE
Field import: velocity_smoother yaw accel ±3.0 (closes #38)

### DIFF
--- a/echoboat_project11/config/nav2_params.240.yaml
+++ b/echoboat_project11/config/nav2_params.240.yaml
@@ -36,8 +36,9 @@ behavior_server:
 
 velocity_smoother:
   ros__parameters:
-    # Yaw is governed by the ACCELERATION cap, not the speed cap (#36). The #197
-    # snap-roll was a yaw *step* (snapped to 1.0 rad/s and reversed → ±30° hull
+    # Yaw is governed by the ACCELERATION cap, not the speed cap (#36). The
+    # deployment-197 (2026-05-29 run) snap-roll was a yaw *step* (snapped to
+    # 1.0 rad/s and reversed → ±30° hull
     # roll), not over-speed. So the steady-state yaw rate keeps the full 1.0 rad/s
     # vectored-thrust capability (matching the helm max_yaw_speed backstop).
     #
@@ -45,10 +46,12 @@ velocity_smoother:
     # The ±0.5 cap (~2 s ramp 0→1.0) lagged the direct-tuned CrabbingPathFollower
     # PID → windup + hunting ("drunk" line-following, XTE median 0.94 m). ±3.0
     # (~0.3 s ramp 0→1.0) restored clean tracking (XTE 0.45 m = the pre-smoother
-    # baseline), confirmed on water. ⚠️ This re-opens the #197 snap-roll risk the
-    # ±0.5 was guarding against — validated only on smooth avoider bends today,
-    # NOT on a sharp yaw step/reversal. SIM-VALIDATE the roll response before
-    # trusting; back off toward ±1.5 if a sharp reversal rolls the hull.
+    # baseline), confirmed on water. ⚠️ This re-opens the deployment-197 snap-roll
+    # risk the ±0.5 was guarding against — validated only on smooth avoider bends
+    # today, NOT on a sharp yaw step/reversal. The sim does NOT model hull-roll
+    # dynamics, so it can't validate this: WATCH for hull roll on sharp yaw
+    # reversals during on-water ops, and back off toward ±1.5 if a sharp reversal
+    # rolls the hull (operator decision, #38 wrap-up).
     max_velocity: [2.75, 0.0, 1.0]
     min_velocity: [-0.5, 0.0, -1.0]
     max_accel: [0.8, 0.0, 3.0]

--- a/echoboat_project11/config/nav2_params.240.yaml
+++ b/echoboat_project11/config/nav2_params.240.yaml
@@ -39,10 +39,17 @@ velocity_smoother:
     # Yaw is governed by the ACCELERATION cap, not the speed cap (#36). The #197
     # snap-roll was a yaw *step* (snapped to 1.0 rad/s and reversed → ±30° hull
     # roll), not over-speed. So the steady-state yaw rate keeps the full 1.0 rad/s
-    # vectored-thrust capability (matching the helm max_yaw_speed backstop) while
-    # the yaw accel/decel cap (±0.5 rad/s², ~2 s ramp 0→1.0) spreads the moment
-    # buildup that drove the roll. Starting value — sim/on-water tunable.
+    # vectored-thrust capability (matching the helm max_yaw_speed backstop).
+    #
+    # 2026-06-02 FIELD TUNE (BizzyBoat/gabby): yaw accel/decel ±0.5 → ±3.0 rad/s².
+    # The ±0.5 cap (~2 s ramp 0→1.0) lagged the direct-tuned CrabbingPathFollower
+    # PID → windup + hunting ("drunk" line-following, XTE median 0.94 m). ±3.0
+    # (~0.3 s ramp 0→1.0) restored clean tracking (XTE 0.45 m = the pre-smoother
+    # baseline), confirmed on water. ⚠️ This re-opens the #197 snap-roll risk the
+    # ±0.5 was guarding against — validated only on smooth avoider bends today,
+    # NOT on a sharp yaw step/reversal. SIM-VALIDATE the roll response before
+    # trusting; back off toward ±1.5 if a sharp reversal rolls the hull.
     max_velocity: [2.75, 0.0, 1.0]
     min_velocity: [-0.5, 0.0, -1.0]
-    max_accel: [0.8, 0.0, 0.5]
-    max_decel: [-0.45, 0.0, -0.5]
+    max_accel: [0.8, 0.0, 3.0]
+    max_decel: [-0.45, 0.0, -3.0]


### PR DESCRIPTION
Imports the field-tested velocity_smoother yaw-accel change from the 2026-06-02 BizzyBoat deployment (rolker/unh_echoboats_project11#205).

`d35a795` — yaw accel/decel **±0.5 → ±3.0** in the shared `nav2_params.240.yaml`. Fixes the line-following hunting caused by the ±0.5 cap lagging the directly-tuned PID; bag-verified (realized yaw-accel cap 0.50→3.00 rad/s², cross-track median 0.94→0.48 m), held through the on-water nav relaunch.

**Retained risk (operator-accepted):** re-opens the snap-roll the ±0.5 guarded against; validated on smooth bends only, not a sharp yaw reversal. Kept as-tested per the wrap-up decision — the sim can't model hull roll, so validation is on-water watch (back off toward ±1.5 if a sharp reversal rolls the hull). Independent of the deployment's swerving root cause (rolker/unh_marine_navigation#63 — that's the AvoidanceController, not the smoother).

Full pre-review in the issue.

Closes #38.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
