### PR TITLE
[#43] CA safety node as default helm gate (replaces Collision Monitor)

### DIFF
--- a/.agent/work-plans/issue-43/progress.md
+++ b/.agent/work-plans/issue-43/progress.md
@@ -1,0 +1,26 @@
+---
+issue: 43
+---
+
+# Issue #43 — Configure & wire the CA safety node for EchoBoat 240
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-05 01:24 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: changes-requested → resolved
+
+**Branch**: feature/issue-43 (seafloor PR #44 + companion unh_echoboats PR #227)
+**Mode**: pre-push (both repos' diffs)
+**Depth**: Deep (reason: deployed-boat safety config, replaces sole helm publisher, cross-repo)
+**Must-fix**: 1 | **Suggestions**: 3
+
+### Findings
+- [x] (must-fix) Composition path launched the Collision Monitor unconditionally + never launched ca_safety → nav2_bringup's contradictory defaults (use_composition=True + use_ca_safety=true) silently downgraded ca_safety→CM (Claude+Copilot cross-confirmed). Fixed `2c14e23`: use_composition default→False + hard OpaqueFunction guard erroring on the use_ca_safety+composition combo.
+- [x] (suggestion) Boat launcher had no one-line revert knob → `5df5e33` threads use_ca_safety through bizzy nav_launch.py.
+- [x] (suggestion) base_frame=base_link relies on tf base_link←base_link_level — same dependency the CM already had; node fails safe on missing tf (catches TransformException → passthrough, verified in #64). No change.
+- [x] (suggestion) viz defaults — publish_visualization defaults on; polygon topics match CAMP's existing reflex-zone overlay. No change.
+
+### Notes
+- Non-composition (field) path verified correct by both reviewers: mutually-exclusive helm publisher, consistent lifecycle-manager node lists, matching param block/topics/frames/odom, preserved CM fallback.
+- test_launch_wiring.py passes (incl. new ca_safety assertions). Pre-existing, NOT from #43: test_param_compose::test_merged_240_hull_values fails (nav2_params.240.yaml yaw accel/decel z=3.0/-3.0 vs #36-intent 0.5) — flagged for separate triage.

--- a/.agent/work-plans/issue-43/progress.md
+++ b/.agent/work-plans/issue-43/progress.md
@@ -24,3 +24,17 @@ issue: 43
 ### Notes
 - Non-composition (field) path verified correct by both reviewers: mutually-exclusive helm publisher, consistent lifecycle-manager node lists, matching param block/topics/frames/odom, preserved CM fallback.
 - test_launch_wiring.py passes (incl. new ca_safety assertions). Pre-existing, NOT from #43: test_param_compose::test_merged_240_hull_values fails (nav2_params.240.yaml yaw accel/decel z=3.0/-3.0 vs #36-intent 0.5) — flagged for separate triage.
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-06-05 01:58 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**PR**: #44 (+ companion unh_echoboats #227)
+**Sources**: Copilot PR review (#44: 3 inline; #227: 0)
+**Verdict**: must-fix already resolved by review-code; remainder addressed in `2191b06`
+
+### Findings
+- [x] (valid, pre-resolved) composition contradictory defaults silently ran the CM — fixed in `2c14e23` (use_composition default→false + hard guard); Copilot independently re-confirmed
+- [x] (valid) use_ca_safety help didn't note non-composition-only → clarified (`2191b06`)
+- [x] (valid) remap test missed the shared `remappings` var → added an explicit assertion (`2191b06`)
+- #227: no actionable findings (clean)

--- a/echoboat_project11/config/nav2_params.base.yaml
+++ b/echoboat_project11/config/nav2_params.base.yaml
@@ -315,6 +315,23 @@ collision_monitor:
     polygons: []
     observation_sources: []
 
+# Marine CA safety node (rolker/unh_marine_navigation#64) — the default helm gate,
+# replacing the Collision Monitor above (use_ca_safety:=false reverts to the CM).
+# Rig-agnostic wiring lives here; zone geometry + the reflex pointcloud topic are
+# supplied per-boat via the instance overlay (instance_params), since they depend
+# on the sensor rig — mirrors the collision_monitor base/overlay split (#3).
+# With no reflex feed (a boat without the reflex cloud) the node sees no obstacles
+# and passes cmd_vel through unchanged, like the Collision Monitor's no-source mode.
+ca_safety:
+  ros__parameters:
+    base_frame: <tf_prefix>/base_link
+    cmd_vel_in_topic: "cmd_vel_smoothed"
+    cmd_vel_out_topic: "piloting_mode/autonomous/cmd_vel"
+    odom_topic: "mavros/local_position/odom"
+    state_topic: "collision_monitor_state"
+    slowdown_polygon_topic: "collision_monitor/slowdown_polygon"
+    stop_polygon_topic: "collision_monitor/stop_polygon"
+
 docking_server:
   ros__parameters:
     controller_frequency: 50.0

--- a/echoboat_project11/launch/nav2_bringup_launch.py
+++ b/echoboat_project11/launch/nav2_bringup_launch.py
@@ -170,8 +170,12 @@ def generate_launch_description():
 
     declare_use_composition_cmd = DeclareLaunchArgument(
         'use_composition',
-        default_value='True',
-        description='Whether to use composed bringup',
+        # Default False so it is self-consistent with use_ca_safety=true (the CA
+        # safety node is a plain node, not a composable component — it runs only
+        # under non-composition). The field already pins this False.
+        default_value='False',
+        description='Whether to use composed bringup. Must be False when '
+        'use_ca_safety is true (the default).',
     )
 
     declare_use_respawn_cmd = DeclareLaunchArgument(

--- a/echoboat_project11/launch/nav2_bringup_launch.py
+++ b/echoboat_project11/launch/nav2_bringup_launch.py
@@ -184,6 +184,13 @@ def generate_launch_description():
         'log_level', default_value='info', description='log level'
     )
 
+    declare_use_ca_safety_cmd = DeclareLaunchArgument(
+        'use_ca_safety',
+        default_value='true',
+        description='Use the marine CA safety node as the helm gate (default); '
+        'false reverts to the nav2 Collision Monitor. Requires use_composition=false.',
+    )
+
     # Specify the actions
     bringup_cmd_group = GroupAction(
         [
@@ -210,6 +217,7 @@ def generate_launch_description():
                     'params_file': params_file,
                     'use_composition': use_composition,
                     'use_respawn': use_respawn,
+                    'use_ca_safety': LaunchConfiguration('use_ca_safety'),
                     'container_name': 'nav2_container',
                 }.items(),
             ),
@@ -235,6 +243,7 @@ def generate_launch_description():
     ld.add_action(declare_use_composition_cmd)
     ld.add_action(declare_use_respawn_cmd)
     ld.add_action(declare_log_level_cmd)
+    ld.add_action(declare_use_ca_safety_cmd)
     ld.add_action(declare_use_localization_cmd)
 
     # Compose base + per-model params into params_file (unless one was passed),

--- a/echoboat_project11/launch/navigation_launch.py
+++ b/echoboat_project11/launch/navigation_launch.py
@@ -40,6 +40,10 @@ def generate_launch_description():
     container_name_full = (namespace, '/', container_name)
     use_respawn = LaunchConfiguration('use_respawn')
     log_level = LaunchConfiguration('log_level')
+    # ca_safety replaces the nav2 Collision Monitor as the helm gate (#64). It is
+    # the default; use_ca_safety:=false reverts to the proven Collision Monitor.
+    # The two are mutually exclusive — exactly one publishes the helm topic.
+    use_ca_safety = LaunchConfiguration('use_ca_safety')
 
     lifecycle_nodes = [
         'controller_server',
@@ -56,6 +60,11 @@ def generate_launch_description():
         'waypoint_follower',
         'docking_server',
     ]
+
+    # When ca_safety is active the Collision Monitor is not launched, so it must
+    # not be in the lifecycle manager's node list (else the manager blocks waiting
+    # for a node that never appears).
+    lifecycle_nodes_no_monitor = [n for n in lifecycle_nodes if n != 'collision_monitor']
 
     # Map fully qualified names to relative ones so the node's namespace can be prepended.
     # In case of the transforms (tf), currently, there doesn't seem to be a better alternative
@@ -127,6 +136,13 @@ def generate_launch_description():
 
     declare_log_level_cmd = DeclareLaunchArgument(
         'log_level', default_value='info', description='log level'
+    )
+
+    declare_use_ca_safety_cmd = DeclareLaunchArgument(
+        'use_ca_safety',
+        default_value='true',
+        description='Use the marine CA safety node (marine_nav_ca_safety) as the helm '
+        'gate (default). Set false to revert to the nav2 Collision Monitor.',
     )
 
     load_nodes = GroupAction(
@@ -253,6 +269,8 @@ def generate_launch_description():
                 namespace="",
                 emulate_tty=True
             ),
+            # Helm gate, option A (fallback): the nav2 Collision Monitor.
+            # Launched only when use_ca_safety:=false.
             LifecycleNode(
                 package='nav2_collision_monitor',
                 executable='collision_monitor',
@@ -264,7 +282,28 @@ def generate_launch_description():
                 arguments=['--ros-args', '--log-level', log_level],
                 remappings=remappings,
                 namespace="",
-                emulate_tty=True
+                emulate_tty=True,
+                condition=UnlessCondition(use_ca_safety),
+            ),
+            # Helm gate, option B (default): the marine CA safety node (#64),
+            # which replaces the Collision Monitor (speed-scaled yaw-preserving
+            # slowdown + reverse-assisted stop). A plain (non-lifecycle) node, so
+            # it is NOT in the lifecycle manager's node list. Reads cmd_vel_smoothed
+            # and publishes the helm topic via its params (sole helm publisher when
+            # active). Requires non-composition (it is not a registered component).
+            Node(
+                package='marine_nav_ca_safety',
+                executable='ca_safety_node',
+                name='ca_safety',
+                output='screen',
+                respawn=use_respawn,
+                respawn_delay=2.0,
+                parameters=[configured_params],
+                arguments=['--ros-args', '--log-level', log_level],
+                remappings=remappings,
+                namespace="",
+                emulate_tty=True,
+                condition=IfCondition(use_ca_safety),
             ),
             LifecycleNode(
                 package='opennav_docking',
@@ -279,6 +318,9 @@ def generate_launch_description():
                 namespace="",
                 emulate_tty=True
             ),
+            # Two mutually-exclusive managers: the node list must match what is
+            # actually launched. With ca_safety active, the Collision Monitor is
+            # absent, so it is dropped from the managed list.
             Node(
                 package='nav2_lifecycle_manager',
                 executable='lifecycle_manager',
@@ -286,7 +328,18 @@ def generate_launch_description():
                 output='screen',
                 arguments=['--ros-args', '--log-level', log_level],
                 parameters=[{'autostart': autostart}, {'node_names': lifecycle_nodes}],
-                emulate_tty=True
+                emulate_tty=True,
+                condition=UnlessCondition(use_ca_safety),
+            ),
+            Node(
+                package='nav2_lifecycle_manager',
+                executable='lifecycle_manager',
+                name='lifecycle_manager_navigation',
+                output='screen',
+                arguments=['--ros-args', '--log-level', log_level],
+                parameters=[{'autostart': autostart}, {'node_names': lifecycle_nodes_no_monitor}],
+                emulate_tty=True,
+                condition=IfCondition(use_ca_safety),
             ),
         ],
     )
@@ -410,6 +463,7 @@ def generate_launch_description():
     ld.add_action(declare_container_name_cmd)
     ld.add_action(declare_use_respawn_cmd)
     ld.add_action(declare_log_level_cmd)
+    ld.add_action(declare_use_ca_safety_cmd)
     # Add the actions to launch all of the navigation nodes
     ld.add_action(load_nodes)
     ld.add_action(load_composable_nodes)

--- a/echoboat_project11/launch/navigation_launch.py
+++ b/echoboat_project11/launch/navigation_launch.py
@@ -17,7 +17,7 @@ import os
 from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, GroupAction, SetEnvironmentVariable
+from launch.actions import DeclareLaunchArgument, GroupAction, OpaqueFunction, SetEnvironmentVariable
 from launch.conditions import IfCondition, UnlessCondition
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import LoadComposableNodes, SetParameter
@@ -25,6 +25,21 @@ from launch_ros.actions import Node
 from launch_ros.actions import LifecycleNode
 from launch_ros.descriptions import ComposableNode, ParameterFile
 from nav2_common.launch import RewrittenYaml
+
+
+def _guard_ca_safety_composition(context, *args, **kwargs):
+    """ca_safety_node is a plain node, not a composable component, so it cannot
+    run under composition. Fail loudly rather than silently downgrading to the
+    Collision Monitor when both are requested (the composition path launches the
+    CM, not ca_safety)."""
+    def _truthy(name):
+        return LaunchConfiguration(name).perform(context).lower() in ('true', '1')
+    if _truthy('use_ca_safety') and _truthy('use_composition'):
+        raise RuntimeError(
+            'use_ca_safety:=true requires use_composition:=false (ca_safety_node is '
+            'not a composable component). Set use_ca_safety:=false to run the '
+            'Collision Monitor under composition.')
+    return []
 
 
 def generate_launch_description():
@@ -464,6 +479,8 @@ def generate_launch_description():
     ld.add_action(declare_use_respawn_cmd)
     ld.add_action(declare_log_level_cmd)
     ld.add_action(declare_use_ca_safety_cmd)
+    # Reject the unsupported use_ca_safety + use_composition combo loudly.
+    ld.add_action(OpaqueFunction(function=_guard_ca_safety_composition))
     # Add the actions to launch all of the navigation nodes
     ld.add_action(load_nodes)
     ld.add_action(load_composable_nodes)

--- a/echoboat_project11/launch/navigation_launch.py
+++ b/echoboat_project11/launch/navigation_launch.py
@@ -157,7 +157,9 @@ def generate_launch_description():
         'use_ca_safety',
         default_value='true',
         description='Use the marine CA safety node (marine_nav_ca_safety) as the helm '
-        'gate (default). Set false to revert to the nav2 Collision Monitor.',
+        'gate (default). Set false to revert to the nav2 Collision Monitor. Only '
+        'effective with use_composition:=false (ca_safety is not a composable '
+        'component); the launch errors if both are true.',
     )
 
     load_nodes = GroupAction(

--- a/echoboat_project11/package.xml
+++ b/echoboat_project11/package.xml
@@ -16,6 +16,7 @@
   <exec_depend>mavros</exec_depend>
   <exec_depend>mavros_extras</exec_depend>
   <exec_depend>nav2_bringup</exec_depend>
+  <exec_depend>marine_nav_ca_safety</exec_depend>
   <exec_depend>echo_helm</exec_depend>
   <exec_depend>ros2launch</exec_depend>
   <!-- param_compose.py imports yaml at launch time (composed by nav2_bringup_launch.py) -->

--- a/echoboat_project11/test/test_launch_wiring.py
+++ b/echoboat_project11/test/test_launch_wiring.py
@@ -194,3 +194,21 @@ def test_ca_safety_params_chain():
     ca = base['ca_safety']['ros__parameters']
     assert ca['cmd_vel_in_topic'] == 'cmd_vel_smoothed'
     assert ca['cmd_vel_out_topic'] == _HELM_TOPIC
+
+
+def _remappings_var_targets(tree):
+    """Remap targets in the module-level `remappings = [...]` assignment."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == 'remappings' for t in node.targets
+        ):
+            return [dst for _, dst in _remap_tuples(node.value)]
+    return []
+
+
+def test_remappings_var_does_not_target_helm_topic():
+    """The shared `remappings` list is applied to ca_safety (and others) via
+    `remappings=remappings`, which `_node_calls()` can't see (it only reads list
+    literals inside the call). A helm-topic remap added to this shared var would
+    slip past the per-node #27 guard, so assert the variable itself is clean."""
+    assert _HELM_TOPIC not in _remappings_var_targets(_launch_tree())

--- a/echoboat_project11/test/test_launch_wiring.py
+++ b/echoboat_project11/test/test_launch_wiring.py
@@ -10,6 +10,11 @@ The Collision Monitor must stay the SOLE publisher on the helm topic
 (piloting_mode/autonomous/cmd_vel). The #27 regression was the smoother
 publishing its output straight to the helm topic, competing with the monitor.
 
+As of #64 the marine CA safety node (`ca_safety`) is the DEFAULT helm gate,
+replacing the Collision Monitor (which stays as the `use_ca_safety:=false`
+fallback). Both read `cmd_vel_smoothed` and emit the helm topic via params, and
+are mutually exclusive in the launch — exactly one publishes the helm topic.
+
 These parse the launch file's AST (no ROS runtime needed) plus the shared base
 params, matching the static style of test_param_compose.py.
 """
@@ -159,3 +164,33 @@ def test_stamped_cmd_vel_consistent_across_chain():
         assert params.get('enable_stamped_cmd_vel') is True, (
             f'{node} must set enable_stamped_cmd_vel: true to match the cmd_vel chain'
         )
+
+
+# --- ca_safety is the default helm gate (#64), replacing the Collision Monitor ---
+
+def test_ca_safety_node_present():
+    """The marine CA safety node is launched as the default helm gate."""
+    names = [c[0] for c in _node_calls(_launch_tree())]
+    assert 'ca_safety' in names, 'ca_safety node not found in launch file'
+
+
+def test_ca_safety_does_not_remap_to_helm_topic():
+    """ca_safety emits the helm topic via its cmd_vel_out_topic param, never a
+    launch remap — the same #27 sole-publisher invariant as the Collision Monitor."""
+    for name, remaps in _node_calls(_launch_tree()):
+        if name == 'ca_safety':
+            targets = [dst for _, dst in remaps]
+            assert _HELM_TOPIC not in targets, (
+                'ca_safety remaps an output to the helm topic — reintroduces the '
+                '#27 double-publisher'
+            )
+
+
+def test_ca_safety_params_chain():
+    """ca_safety reads the smoother output and emits the helm topic — the same
+    chain endpoints as the Collision Monitor it replaces."""
+    with open(os.path.join(_CONFIG, 'nav2_params.base.yaml')) as f:
+        base = yaml.safe_load(f)
+    ca = base['ca_safety']['ros__parameters']
+    assert ca['cmd_vel_in_topic'] == 'cmd_vel_smoothed'
+    assert ca['cmd_vel_out_topic'] == _HELM_TOPIC


### PR DESCRIPTION
Closes #43

Wire the marine **CA safety node** (`ca_safety_node` from `marine_nav_ca_safety`, rolker/unh_marine_navigation#64) as the **default helm gate**, replacing the nav2 Collision Monitor, with a `use_ca_safety` launch arg (default `true`) to revert to the Collision Monitor in the field.

## Changes (generic `echoboat_project11`)
- **`navigation_launch.py`**: `use_ca_safety` arg; `ca_safety` (plain Node) gated `IfCondition`, Collision Monitor gated `UnlessCondition`; lifecycle manager split into with-/without-`collision_monitor` variants (the managed node list must match what actually launches). The two helm gates are mutually exclusive → the **sole-helm-publisher invariant (#27) is preserved**. `ca_safety` requires `use_composition=false` (not a registered component; the field uses non-composition).
- **`nav2_bringup_launch.py`**: declare + forward `use_ca_safety`.
- **`nav2_params.base.yaml`**: rig-agnostic `ca_safety` block (frames via `<tf_prefix>`, `cmd_vel_smoothed`→`piloting_mode/autonomous/cmd_vel`, odom `mavros/local_position/odom`, state + viz polygon topics). Zone geometry is per-boat (instance overlay), mirroring the collision_monitor base/overlay split (#3).
- **`package.xml`**: `exec_depend` on `marine_nav_ca_safety`.
- **`test_launch_wiring.py`**: assert `ca_safety` present, no helm remap, param chain.

## Companion / dependency
- 240 zone tuning + reflex feed: PR on `unh_echoboats_project11` (bizzyboat overlay).
- **Runtime dep:** `marine_nav_ca_safety` lands with rolker/unh_marine_navigation#64 — merge/build that first (or together).

## Test notes
- `test_launch_wiring.py` (incl. new ca_safety assertions) passes; build clean.
- ⚠️ **Pre-existing, not from this PR:** `test_param_compose::test_merged_240_hull_values` fails — `nav2_params.240.yaml` has `velocity_smoother` yaw `max_accel`/`max_decel` z = `3.0`/`-3.0`, but the test expects the #36 governor's `0.5`/`-0.5`. I touched neither file. Possible #36 yaw-accel regression **or** a stale test — flagged for separate triage.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
