### PR TITLE
test_param_compose: re-lock 240 yaw accel/decel at deployed ±3.0 (#45)

### DIFF
--- a/echoboat_project11/test/test_param_compose.py
+++ b/echoboat_project11/test/test_param_compose.py
@@ -82,12 +82,17 @@ def test_merged_240_hull_values():
     assert _gc(p)['robot_radius'] == 1.5
     assert 'footprint' in _lc(p) and 'footprint' in _gc(p)
     assert p['planner_server']['ros__parameters']['GridBased']['minimum_turning_radius'] == 1.5
-    # Yaw speed cap is the full 1.0 rad/s capability; the yaw accel cap is the
-    # governor (#36). Guards against a revert to the old 0.45 survey speed clamp.
+    # Yaw uses the full 1.0 rad/s speed cap; the governor is the yaw ACCEL cap.
+    # Field-tuned +-0.5 -> +-3.0 (d35a795, 2026-06-02 gabby): +-0.5 (~2 s ramp)
+    # lagged the CrabbingPathFollower PID -> line-following hunting (XTE 0.94 m);
+    # +-3.0 (~0.3 s ramp) restored clean tracking (XTE 0.45 m), confirmed on water.
+    # Locks the deployed value against an accidental revert. NB +-3.0 re-opens the
+    # deployment-197 snap-roll risk -> on-water roll watch / back-off to +-1.5 is a
+    # deployment check (echoboats #228), not a test concern.
     vs = p['velocity_smoother']['ros__parameters']
     assert vs['max_velocity'] == [2.75, 0.0, 1.0]
-    assert vs['max_accel'] == [0.8, 0.0, 0.5]
-    assert vs['max_decel'] == [-0.45, 0.0, -0.5]
+    assert vs['max_accel'] == [0.8, 0.0, 3.0]
+    assert vs['max_decel'] == [-0.45, 0.0, -3.0]
     bs = p['behavior_server']['ros__parameters']
     assert bs['max_rotational_vel'] == 1.0
     assert bs['hover']['maximum_speed'] == 1.0


### PR DESCRIPTION
Closes #45

Re-lock the 240 `velocity_smoother` yaw `max_accel`/`max_decel` assertion in
`test_param_compose` at the **deployed ±3.0**, fixing a stale test that has failed since
2026-06-02.

**Triage (stale test, not a config regression):** `7ce1299` (#36) set ±0.5 and added the
test; `d35a795` (2026-06-02 gabby field tune) **deliberately raised ±0.5 → ±3.0** — the
±0.5 cap lagged the CrabbingPathFollower PID → line-following hunting (XTE 0.94 m); ±3.0
restored clean tracking (XTE 0.45 m), confirmed on water — but didn't update the test.

This syncs the expected value to the intended/deployed ±3.0 and refreshes the comment to
cite the field tune. The test's guard purpose (lock the governor against an accidental
revert) is preserved.

**Out of scope:** ±3.0 re-opens the deployment-197 snap-roll risk (validated only on smooth
bends); the on-water roll watch / back-off-to-±1.5 decision is a goal in deployment
rolker/unh_echoboats_project11#228.

`test_param_compose` + `test_launch_wiring` pass.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
